### PR TITLE
refactor(zwave_js): replace duplicated interview event literals with constant

### DIFF
--- a/homeassistant/components/zwave_js/api.py
+++ b/homeassistant/components/zwave_js/api.py
@@ -144,6 +144,12 @@ CLIENT_SIDE_AUTH = "clientSideAuth"
 # constants for inclusion
 INCLUSION_STRATEGY = "inclusion_strategy"
 
+#Refactor-Status change
+INTERVIEW_STARTED = "interview started"
+INTERVIEW_COMPLETED = "interview completed"
+INTERVIEW_STAGE_COMPLETED = "interview stage completed"
+INTERVIEW_FAILED = "interview failed"
+
 INCLUSION_STRATEGY_NOT_SMART_START: dict[
     int,
     Literal[
@@ -775,10 +781,10 @@ async def websocket_add_node(
         node: Node, low_security: bool, low_security_reason: str | None
     ) -> None:
         interview_unsubs = [
-            node.on("interview started", forward_event),
-            node.on("interview completed", forward_event),
-            node.on("interview stage completed", forward_stage),
-            node.on("interview failed", forward_event),
+            node.on("INTERVIEW_STARTED", forward_event),
+            node.on("INTERVIEW_COMPLETED", forward_event),
+            node.on("INTERVIEW_STAGE_COMPLETED", forward_stage),
+            node.on("INTERVIEW_FAILED", forward_event),
         ]
         unsubs.extend(interview_unsubs)
         node_details = {
@@ -1562,10 +1568,10 @@ async def websocket_replace_failed_node(
     def node_added(event: dict) -> None:
         node = event["node"]
         interview_unsubs = [
-            node.on("interview started", forward_event),
-            node.on("interview completed", forward_event),
-            node.on("interview stage completed", forward_stage),
-            node.on("interview failed", forward_event),
+            node.on("INTERVIEW_STARTED", forward_event),
+            node.on("INTERVIEW_COMPLETED", forward_event),
+            node.on("INTERVIEW_STAGE_COMPLETED", forward_stage),
+            node.on("INTERVIEW_FAILED", forward_event),
         ]
         unsubs.extend(interview_unsubs)
         node_details = {
@@ -1862,10 +1868,10 @@ async def websocket_refresh_node_info(
 
     connection.subscriptions[msg["id"]] = async_cleanup
     msg[DATA_UNSUBSCRIBE] = unsubs = [
-        node.on("interview started", forward_event),
-        node.on("interview completed", forward_event),
-        node.on("interview stage completed", forward_stage),
-        node.on("interview failed", forward_event),
+        node.on("INTERVIEW_STARTED", forward_event),
+        node.on("INTERVIEW_COMPLETED", forward_event),
+        node.on("INTERVIEW_STAGE_COMPLETED", forward_stage),
+        node.on("INTERVIEW_FAILED", forward_event),
     ]
 
     await node.async_refresh_info()


### PR DESCRIPTION
…constants

## change
<!--
Refactor: extract constant for "interview started" and other 3 in "homeassistant/components/zwave_js/api.py"
-->

## Motivation
<!--
The string literal "interview started" and other 3 are duplicated multiple times in api.py. Duplicating literals introduces a risk of inconsistency and makes future changes harder if the literal needs to be updated, we would need to locate and change it in multiple places, which is error-prone. Using a named constant improves readability, reduces maintenance cost, and ensures consistency.
-->

## Addressed the issue:
<!--
I introduced a new constant 

INTERVIEW_STARTED = "interview started"
INTERVIEW_COMPLETED = "interview completed"
INTERVIEW_STAGE_COMPLETED = "interview stage completed"
INTERVIEW_FAILED = "interview failed" 

at the top of the file and replaced all occurrences of the literal "interview started" with this constant. This centralizes the event name in one location.
-->

## After doing this:
<!--
- Eliminates duplication of string literals.
- Improves maintainability by ensuring the event name is defined in one place only.
- Makes the code more self-documenting (the constant name describes the event clearly).
-->

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->
<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
