### PR TITLE
Change expected type

### DIFF
--- a/homeassistant/components/lidarr/__init__.py
+++ b/homeassistant/components/lidarr/__init__.py
@@ -39,7 +39,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: LidarrConfigEntry) -> bo
         session=async_get_clientsession(hass, host_configuration.verify_ssl),
         request_timeout=60,
     )
-    data = LidarrData(
+    data: LidarrData = LidarrData(
         disk_space=DiskSpaceDataUpdateCoordinator(
             hass, entry, host_configuration, lidarr
         ),

--- a/homeassistant/components/lidarr/__init__.py
+++ b/homeassistant/components/lidarr/__init__.py
@@ -48,7 +48,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: LidarrConfigEntry) -> bo
         wanted=WantedDataUpdateCoordinator(hass, entry, host_configuration, lidarr),
         albums=AlbumsDataUpdateCoordinator(hass, entry, host_configuration, lidarr),
     )
-    for field in fields(data):
+    for field in fields(LidarrData):
         coordinator = getattr(data, field.name)
         await coordinator.async_config_entry_first_refresh()
     device_registry = dr.async_get(hass)


### PR DESCRIPTION
Sofia Blom - Group 6
This issue scored a 10 out of 18 points in our prioritization criteria. In other words it's not an immediate problem but something that should probably be looked at at some point. 

The smell Sonar Cube filed this under is "Arguments given to a function should be of an expected type". It is my understanding that Sonar Cube found this issue when performing a static analysis of the project. Python, being a dynamically typed language, does not enforce types. This can make it easy to give a function arguments that are not allowed to a function. Type hinting doesn't solve this problem but it will make developers using the functions more aware of what the function expects. This is why Sonar Cube does highlight issues such as this one as it could break a system if an error is thrown unexpectedly. 

The problem with a static analyser is that it is unable to evaluate the types entirely without executing the code. Thus Sonar Cube has flagged a number of "Arguments given to a function should be of an expected type" that when inspecting the code are entirely correct. Sonar Cube would rather flag more issues then miss one thus they are a bit over zealous. 

I have looked at this issue and it is my opinion that the code is used correctly already. I have made changes in an attempt to appease Sonar Cube, which appears to have succeeded. I have also looked at other issues of the same code smell and they appear to be very similar to the one here, with exception to the tests. Some of the tests that I looked at deliberately send in an incorrect type (mostly None) to test the robustness of the code. 