### PR TITLE
Type hint fix for tplink_omada test file

### DIFF
--- a/tests/components/tplink_omada/conftest.py
+++ b/tests/components/tplink_omada/conftest.py
@@ -90,7 +90,7 @@ async def mock_omada_site_client(hass: HomeAssistant) -> AsyncGenerator[AsyncMoc
 
 
 @pytest.fixture
-def mock_omada_clients_only_site_client(hass: HomeAssistant) -> Generator[AsyncMock]:
+def mock_omada_clients_only_site_client(hass: HomeAssistant) -> MagicMock:
     """Mock Omada site client containing only client connection data."""
     site_client = MagicMock()
 


### PR DESCRIPTION
Nicholas, Group 8
The code smell here is that in the file tests/components/tplink_omada/conftest.py there is a function that does not return the same type as the type hint suggests, which was found with sonarcloud. 

This issue fits our prioritisation criteria due to the file being sufficiently large, the fix improves readability, there is another issue of the same type in the same file, the fix is simple and it is also within our selected date range. 

Additionally since test functions can be and are reused, if someone were to reuse this function it would be good if they knew what to expect as a return value. 

The fix itself is very simple, the function mock_omada_clients_only_site_client returns a MagicMock so the type hint is changed to reflect this which immediately shows what the function will return and this should improve readability.  

Test results:
<img width="1437" height="261" alt="omada_test" src="https://github.com/user-attachments/assets/56f09d2a-c624-4d30-81d8-d4e3bdf8dfdb" />