### PR TITLE
Type hint fix of validate_media_player_features in Homekit integration

### DIFF
--- a/homeassistant/components/homekit/util.py
+++ b/homeassistant/components/homekit/util.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 import io
 import ipaddress
 import logging
@@ -399,7 +400,9 @@ def get_media_player_features(state: State) -> list[str]:
     return supported_modes
 
 
-def validate_media_player_features(state: State, feature_list: str) -> bool:
+def validate_media_player_features(
+    state: State, feature_list: Mapping[str, Any]
+) -> bool:
     """Validate features for media players."""
     if not (supported_modes := get_media_player_features(state)):
         _LOGGER.error("%s does not support any media_player features", state.entity_id)


### PR DESCRIPTION
Arno Lécrivain

### Issue

Type hint fix of the method `validate_media_player_features` .

### Motivation
This issue was prioritized, even if it's a very small change because this misleading parameter type has persisted into the codebase for more than 3years. Since the file is not updated very frequently, the lack of context increases risk that future contributors will introduce bugs by misunderstanding the function's arguments. This fix also resolves three issues in the tests that were calling the method with the correct arguments that did not match the incorrect expected type. 

Accurate type hints are essential for readability, for static analysis tools, and for building trust in the annotations. An incorrect type hint undermines all of these, making the code harder to maintain in the long run.

### Resolution
The issue was fixed by changing the type hint of *feature_list* from _string_ to get the actual type that was expected (_Mapping[str, Any]_) in `validate_media_player_features`. This ensures that futures maintainers clearly understand how to call the function when needed.

The change is low-risk since it only touches annotations and does not alter runtime behavior. However, it meaningfully improves readability and trust in the code.