### PR TITLE
fix: reduce complexity _async_update_data

### DIFF
--- a/homeassistant/components/slide_local/coordinator.py
+++ b/homeassistant/components/slide_local/coordinator.py
@@ -92,31 +92,28 @@ class SlideCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 translation_key="update_error",
             )
 
-        if "pos" in data:
-            if self.data is None:
-                oldpos = None
-            else:
-                oldpos = self.data.get("pos")
+        if "pos" not in data:
+            _LOGGER.debug("Nothing to update. Returning data: %s", data)
+            return data
 
-            data["pos"] = max(0, min(1, data["pos"]))
+        oldpos = self.data.get("pos") if self.data else None
+        data["pos"] = max(0, min(1, data["pos"]))
 
-            if not self.config_entry.options.get(CONF_INVERT_POSITION, False):
-                # For slide 0->open, 1->closed; for HA 0->closed, 1->open
-                # Value has therefore to be inverted, unless CONF_INVERT_POSITION is true
-                data["pos"] = 1 - data["pos"]
+        if not self.config_entry.options.get(CONF_INVERT_POSITION, False):
+            # For slide 0->open, 1->closed; for HA 0->closed, 1->open
+            # Value has therefore to be inverted, unless CONF_INVERT_POSITION is true
+            data["pos"] = 1 - data["pos"]
 
-            if oldpos is None or oldpos == data["pos"]:
-                data["state"] = (
-                    STATE_CLOSED if data["pos"] < DEFAULT_OFFSET else STATE_OPEN
-                )
-            elif oldpos > data["pos"]:
-                data["state"] = (
-                    STATE_CLOSED if data["pos"] <= DEFAULT_OFFSET else STATE_CLOSING
-                )
-            else:
-                data["state"] = (
-                    STATE_OPEN if data["pos"] >= (1 - DEFAULT_OFFSET) else STATE_OPENING
-                )
+        if oldpos is None or oldpos == data["pos"]:
+            data["state"] = STATE_CLOSED if data["pos"] < DEFAULT_OFFSET else STATE_OPEN
+        elif oldpos > data["pos"]:
+            data["state"] = (
+                STATE_CLOSED if data["pos"] <= DEFAULT_OFFSET else STATE_CLOSING
+            )
+        else:
+            data["state"] = (
+                STATE_OPEN if data["pos"] >= (1 - DEFAULT_OFFSET) else STATE_OPENING
+            )
 
         _LOGGER.debug("Data successfully updated: %s", data)
 


### PR DESCRIPTION
Julia Winkler, Group 8

## Proposed change and Motivation
This Pull request aims to reduce the cognitive complexity of `_async_update_data()` in `homeassistent/components/slide_local/coordinator.py`. The function was initially attributed with 22 of the 15 allowed breaks to the linear code flow.

Functions that have a high level of complexity increase the maintenance effort as the effort for comprehension is higher, which contributes to the overall time needed to resolve potential bugs, errors or other maintenance tasks. High cognitive complexity, as with this issue, often comes with nested code, which is hard to read and makes it harder to analyze the code follow.

I chose this specific issue following our prioritization criteria. The file has more the 50 lines, which means it should be considered. The proposed solution increases the readability while being not too complex to refactor, as it e.g. doesn't heavliy relay on out side function. Also the function makes up ~50 lines of the file, which leads to a intensity of ~40%

## Type of change
The code snippet has in relation to the function size long nested code block, which can be unnested by inverting the condition and handling the short option first before handling the long one. This improves readability as it cleans up the flow of the code, with even adding a new log message. The second small change is to replace the assignment of `oldpos` with a one-line if statement. Through this change it is clear on first sight that the variable is assigned a value at this point and the condition only needs to be comprehended if this information is of interesst.

## Additional information

<img width="1115" height="382" alt="image" src="https://github.com/user-attachments/assets/ffb78e01-ddb0-4a95-bc88-234aa0392795" />

https://sonarcloud.io/project/issues?directories=homeassistant%2Fcomponents%2Fslide_local&issueStatuses=OPEN%2CCONFIRMED&id=xtrilogis_home-assistant-core-ht25&open=AZlw5hJcQfm9iqjbVgIr
