### PR TITLE
Fix/systemmonitor sensor reduce complexity

### DIFF
--- a/homeassistant/components/systemmonitor/sensor.py
+++ b/homeassistant/components/systemmonitor/sensor.py
@@ -431,20 +431,13 @@ async def async_setup_entry(
     _LOGGER.debug("Setup from options %s", entry.options)
 
     for _type, sensor_description in SENSOR_TYPES.items():
-        # gen = (x for x in xyz if x not in a)
-
-        # for x in gen:
-        #     print(x)
         filtered_sensors = (
             sensor_argument
             for sensor_type, sensor_argument in SENSORS_WITH_ARG.items()
             if _type.startswith(sensor_type)
         )
-        for sensor_argument in filtered_sensors:
-            # SENSORS_WITH_ARG.items():  sensor_type,
-            # if not _type.startswith(sensor_type):
-            #     continue
 
+        for sensor_argument in filtered_sensors:
             filtered_resources = (
                 argument
                 for argument in startup_arguments[sensor_argument]
@@ -452,11 +445,6 @@ async def async_setup_entry(
             )
 
             for argument in filtered_resources:
-                # startup_arguments[sensor_argument]:
-                # if (_add := slugify(f"{_type}_{argument}")) in loaded_resources:
-                #     continue
-
-                # generator
                 is_enabled = check_legacy_resource(
                     f"{_type}_{argument}", legacy_resources
                 )
@@ -470,7 +458,6 @@ async def async_setup_entry(
                         is_enabled,
                     )
                 )
-            # continue
 
         if _type.startswith(SENSORS_NO_ARG):
             argument = ""
@@ -503,7 +490,6 @@ async def async_setup_entry(
                     is_enabled,
                 )
             )
-            continue
 
     # Ensure legacy imported disk_* resources are loaded if they are not part
     # of mount points automatically discovered
@@ -512,10 +498,6 @@ async def async_setup_entry(
     )
 
     for resource in filtered_legacy_resources:
-        # legacy_resources:
-        # if not resource.startswith("disk_"):
-        #     continue
-
         check_resource = slugify(resource)
         _LOGGER.debug(
             "Check resource %s already loaded in %s",
@@ -540,29 +522,6 @@ async def async_setup_entry(
                 True,
             )
         )
-
-        # if resource.startswith("disk_"):
-        #     check_resource = slugify(resource)
-        #     _LOGGER.debug(
-        #         "Check resource %s already loaded in %s",
-        #         check_resource,
-        #         loaded_resources,
-        #     )
-        #     if check_resource not in loaded_resources:
-        #         loaded_resources.add(check_resource)
-        #         split_index = resource.rfind("_")
-        #         _type = resource[:split_index]
-        #         argument = resource[split_index + 1 :]
-        #         _LOGGER.debug("Loading legacy %s with argument %s", _type, argument)
-        #         entities.append(
-        #             SystemMonitorSensor(
-        #                 coordinator,
-        #                 SENSOR_TYPES[_type],
-        #                 entry.entry_id,
-        #                 argument,
-        #                 True,
-        #             )
-        #         )
 
     @callback
     def clean_obsolete_entities() -> None:

--- a/homeassistant/components/systemmonitor/sensor.py
+++ b/homeassistant/components/systemmonitor/sensor.py
@@ -414,6 +414,10 @@ async def async_setup_entry(
     psutil_wrapper = entry.runtime_data.psutil_wrapper
     sensor_data = coordinator.data
 
+    cpu_temperature: float | None = None
+    with contextlib.suppress(AttributeError):
+        cpu_temperature = read_cpu_temperature(sensor_data.temperatures)
+
     def get_arguments() -> dict[str, Any]:
         """Return startup information."""
         return {
@@ -421,33 +425,34 @@ async def async_setup_entry(
             "network_arguments": get_all_network_interfaces(hass, psutil_wrapper),
         }
 
-    cpu_temperature: float | None = None
-    with contextlib.suppress(AttributeError):
-        cpu_temperature = read_cpu_temperature(sensor_data.temperatures)
-
     startup_arguments = await hass.async_add_executor_job(get_arguments)
     startup_arguments["cpu_temperature"] = cpu_temperature
 
     _LOGGER.debug("Setup from options %s", entry.options)
+
     for _type, sensor_description in SENSOR_TYPES.items():
         for sensor_type, sensor_argument in SENSORS_WITH_ARG.items():
-            if _type.startswith(sensor_type):
-                for argument in startup_arguments[sensor_argument]:
-                    is_enabled = check_legacy_resource(
-                        f"{_type}_{argument}", legacy_resources
-                    )
-                    if (_add := slugify(f"{_type}_{argument}")) not in loaded_resources:
-                        loaded_resources.add(_add)
-                        entities.append(
-                            SystemMonitorSensor(
-                                coordinator,
-                                sensor_description,
-                                entry.entry_id,
-                                argument,
-                                is_enabled,
-                            )
-                        )
+            if not _type.startswith(sensor_type):
                 continue
+
+            for argument in startup_arguments[sensor_argument]:
+                is_enabled = check_legacy_resource(
+                    f"{_type}_{argument}", legacy_resources
+                )
+                if (_add := slugify(f"{_type}_{argument}")) in loaded_resources:
+                    continue
+
+                loaded_resources.add(_add)
+                entities.append(
+                    SystemMonitorSensor(
+                        coordinator,
+                        sensor_description,
+                        entry.entry_id,
+                        argument,
+                        is_enabled,
+                    )
+                )
+            # continue
 
         if _type.startswith(SENSORS_NO_ARG):
             argument = ""
@@ -485,28 +490,56 @@ async def async_setup_entry(
     # Ensure legacy imported disk_* resources are loaded if they are not part
     # of mount points automatically discovered
     for resource in legacy_resources:
-        if resource.startswith("disk_"):
-            check_resource = slugify(resource)
-            _LOGGER.debug(
-                "Check resource %s already loaded in %s",
-                check_resource,
-                loaded_resources,
+        if not resource.startswith("disk_"):
+            continue
+
+        check_resource = slugify(resource)
+        _LOGGER.debug(
+            "Check resource %s already loaded in %s",
+            check_resource,
+            loaded_resources,
+        )
+
+        if check_resource in loaded_resources:
+            continue
+
+        loaded_resources.add(check_resource)
+        split_index = resource.rfind("_")
+        _type = resource[:split_index]
+        argument = resource[split_index + 1 :]
+        _LOGGER.debug("Loading legacy %s with argument %s", _type, argument)
+        entities.append(
+            SystemMonitorSensor(
+                coordinator,
+                SENSOR_TYPES[_type],
+                entry.entry_id,
+                argument,
+                True,
             )
-            if check_resource not in loaded_resources:
-                loaded_resources.add(check_resource)
-                split_index = resource.rfind("_")
-                _type = resource[:split_index]
-                argument = resource[split_index + 1 :]
-                _LOGGER.debug("Loading legacy %s with argument %s", _type, argument)
-                entities.append(
-                    SystemMonitorSensor(
-                        coordinator,
-                        SENSOR_TYPES[_type],
-                        entry.entry_id,
-                        argument,
-                        True,
-                    )
-                )
+        )
+
+        # if resource.startswith("disk_"):
+        #     check_resource = slugify(resource)
+        #     _LOGGER.debug(
+        #         "Check resource %s already loaded in %s",
+        #         check_resource,
+        #         loaded_resources,
+        #     )
+        #     if check_resource not in loaded_resources:
+        #         loaded_resources.add(check_resource)
+        #         split_index = resource.rfind("_")
+        #         _type = resource[:split_index]
+        #         argument = resource[split_index + 1 :]
+        #         _LOGGER.debug("Loading legacy %s with argument %s", _type, argument)
+        #         entities.append(
+        #             SystemMonitorSensor(
+        #                 coordinator,
+        #                 SENSOR_TYPES[_type],
+        #                 entry.entry_id,
+        #                 argument,
+        #                 True,
+        #             )
+        #         )
 
     @callback
     def clean_obsolete_entities() -> None:

--- a/homeassistant/components/systemmonitor/sensor.py
+++ b/homeassistant/components/systemmonitor/sensor.py
@@ -431,17 +431,35 @@ async def async_setup_entry(
     _LOGGER.debug("Setup from options %s", entry.options)
 
     for _type, sensor_description in SENSOR_TYPES.items():
-        for sensor_type, sensor_argument in SENSORS_WITH_ARG.items():
-            if not _type.startswith(sensor_type):
-                continue
+        # gen = (x for x in xyz if x not in a)
 
-            for argument in startup_arguments[sensor_argument]:
+        # for x in gen:
+        #     print(x)
+        filtered_sensors = (
+            sensor_argument
+            for sensor_type, sensor_argument in SENSORS_WITH_ARG.items()
+            if _type.startswith(sensor_type)
+        )
+        for sensor_argument in filtered_sensors:
+            # SENSORS_WITH_ARG.items():  sensor_type,
+            # if not _type.startswith(sensor_type):
+            #     continue
+
+            filtered_resources = (
+                argument
+                for argument in startup_arguments[sensor_argument]
+                if (_add := slugify(f"{_type}_{argument}")) not in loaded_resources
+            )
+
+            for argument in filtered_resources:
+                # startup_arguments[sensor_argument]:
+                # if (_add := slugify(f"{_type}_{argument}")) in loaded_resources:
+                #     continue
+
+                # generator
                 is_enabled = check_legacy_resource(
                     f"{_type}_{argument}", legacy_resources
                 )
-                if (_add := slugify(f"{_type}_{argument}")) in loaded_resources:
-                    continue
-
                 loaded_resources.add(_add)
                 entities.append(
                     SystemMonitorSensor(
@@ -489,9 +507,14 @@ async def async_setup_entry(
 
     # Ensure legacy imported disk_* resources are loaded if they are not part
     # of mount points automatically discovered
-    for resource in legacy_resources:
-        if not resource.startswith("disk_"):
-            continue
+    filtered_legacy_resources = (
+        resource for resource in legacy_resources if resource.startswith("disk_")
+    )
+
+    for resource in filtered_legacy_resources:
+        # legacy_resources:
+        # if not resource.startswith("disk_"):
+        #     continue
 
         check_resource = slugify(resource)
         _LOGGER.debug(


### PR DESCRIPTION
Julia Winkler, Group 8

## Proposed change and Motivation
This Pull request aims to reduce the cognitive complexity of `async_setup_entry()` in `homeassistent/components/systemmonito/sensor.py`. The function was initially attributed with 34 of the 15 allowed breaks to the linear code flow.

Functions that have a high level of complexity increase the maintenance effort as the effort for comprehension is higher, which contributes to the overall time needed to resolve potential bugs, errors or other maintenance tasks. High cognitive complexity, as with this issue, often comes with nested code, which is hard to read and makes it harder to analyze the code follow.

I chose this specific issue as its complexity is relatively high with about double the amount of breaks in the code flow compared to the guideline. Yet, the function is still refactorable in a decent amount of time. This issue is also prioritized as the method is used 41 times and therefore might profit from a overall improved readability and compressions.

## Type of change
The main complexity stems from a high number of nested for loops which then have one nested condition on wether to execute a code snipped or skip the current iteration. To reduce this nesting the first step is to invert the condition, so that the continue action is clear from the start. This can than be further improved by filtering the items to iterate before starting the for loop. This improves readability as it clears the code flow from "we iterate, than sometimes do something" to "we only look add a sub set, for this sub set we do something".  As a side effect the subset can now be analysed on ist own when debugging.
Another small step is to reorder the first lines, so that the local function `get_arguments()` is closer to it's actually usage. This reduces the effort to jump around in the code.

These changes reduce the complexity from 34 to 22, which is still above the threshold. I quickly want to motivate, why I would not do further refactoring. From my point of view the next possible step would be to introduce to new function to handle a the first set of for loops, which creates SystemMonitorSensor for the current configuration, and the second block, which handles the same for legacy resources. Since I would follow the home assistant style of using mostly local methods for non public methods, these to functions would still be inside of `async_setup_entry()`. The trade-off of breaking down the function and modularising it to introducing method overhead, in my opinion balances out as the parts are already sort of bundled together in their main for loop.


## Additional information
Testing results
<img width="889" height="458" alt="image" src="https://github.com/user-attachments/assets/d14135f4-c682-4a39-b239-8e4651d64826" />

https://sonarcloud.io/project/issues?directories=homeassistant%2Fcomponents%2Fsystemmonitor&issueStatuses=OPEN%2CCONFIRMED&id=xtrilogis_home-assistant-core-ht25&open=AZlw5dQdQfm9iqjbVfsK