### PR TITLE
fix BaseSwitch.asyncupdate code smell: conditional logic

### DIFF
--- a/homeassistant/components/modbus/entity.py
+++ b/homeassistant/components/modbus/entity.py
@@ -373,11 +373,11 @@ class BaseSwitch(BasePlatform, ToggleEntity, RestoreEntity):
                 self._attr_is_on = True
             elif value in self._state_off:
                 self._attr_is_on = False
-            elif value is not None:
+            else:
                 _LOGGER.error(
                     (
                         "Unexpected response from modbus device slave %s register %s,"
-                        " got 0x%2x"
+                        " got 0x%02x"
                     ),
                     self._slave,
                     self._verify_address,


### PR DESCRIPTION
Majdi Albridi
PA2558

In BaseSwitch.asyncupdate I changed the line which had elif value is not None: to an else. The old condition was redundant and misleading as value is always an int. The new version uses the explicit control flow: stateon values activate the switch, stateoff values deactivate the switch, and all other combinations result in an error. I also changed the log format back to 0x%02x.

The change eliminates dead code, enhances readability and makes the logic easier to understand by the future maintainers. Every test (pre-commit and pytest) was successful and it was checked manually that everything was not working as expected. Not much risk because valid values are not affected.
