### PR TITLE
Fix: Remove this identity check; it will always be True in modbus/entity L420

### DIFF
--- a/homeassistant/components/modbus/entity.py
+++ b/homeassistant/components/modbus/entity.py
@@ -417,7 +417,7 @@ class BaseSwitch(BasePlatform, ToggleEntity, RestoreEntity):
                 self._attr_is_on = True
             elif value in self._state_off:
                 self._attr_is_on = False
-            elif value is not None:
+            else:
                 _LOGGER.error(
                     (
                         "Unexpected response from modbus device slave %s register %s,"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
Anna Makarudze, Group 4

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This pull request aims to remove a comparison to None that is redundant because the value being compared to None will always be True, as it would already have been used in other computations before the check is made. A comparison to None should only be made when a value is can be None. If the comparison is made with a value that is always True and never None, it is unnecessary and only makes the code more confusing and less readable.

The comparison to `None `in this code snippet is being done after a value has already been converted to an integer in an earlier step in L415. If the value is `None` at that step, an exception will be thrown, as shown in the image below. Therefore, checking if a value is not `None` in L420 is redundant because it is already expected that it is not `None` if the exception was not thrown when the conversion to `int` was done in L415. This line should be expected to cater for all other values that are `True` but just not in `self.state_on` or `self.state_off`. 
<img width="491" height="125" alt="Screenshot 2025-10-03 at 12 32 30" src="https://github.com/user-attachments/assets/ea670305-48ad-412e-bfeb-e5d169b42b98" />

I chose this issue because the code's current structure can be confusing and needs revision to improve readability. I also chose to change it because the issue was introduced 4 years ago, and over the years, it has been introduced in other parts of the codebase. Suppose a code smell exists for a long time. In that case, there is a danger of new contributors introducing more code smells similar to the original code smell, as they tend to read the code to see how it has been implemented elsewhere and base their contributions on prior contributions, which, unfortunately, increases the number of code smells. This code smell had 33 open issues, and only 4 issues were older or the same age as this issue, meaning 28 more code smells similar to this one were introduced after this issue. I also selected this issue because most of the other issues were either younger than this one or in test files, as the effort required for all the issues for this code smell was similar. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->
The change removes the comparison to `is not None` for a value that is never `None` and works for all values that are `True`, but outside of the expected values.

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
Testing results are shown below:
<img width="821" height="367" alt="Screenshot 2025-10-03 at 12 30 26" src="https://github.com/user-attachments/assets/6ed27a67-50ca-4a9e-87e5-dd3ac969c114" />

Link to the updated SonarQube Cloud report https://sonarcloud.io/project/issues?impactSeverities=HIGH&rules=python%3AS5727&severities=CRITICAL&issueStatuses=OPEN%2CCONFIRMED&types=CODE_SMELL&id=amakarudze_home-assistant-core-ht25&open=AZl76pEWGK_6v4YRuEyY

