### PR TITLE
Fix Code Smell Comparison to None should not be constant

### DIFF
--- a/homeassistant/components/energy/validate.py
+++ b/homeassistant/components/energy/validate.py
@@ -190,12 +190,12 @@ def _async_validate_usage_stat(
         return
 
     try:
-        current_value: float | None = float(state.state)
-    except ValueError:
+        current_value: float = float(state.state)
+    except (ValueError, TypeError):
         issues.add_issue(hass, "entity_state_non_numeric", entity_id, state.state)
         return
 
-    if current_value is not None and current_value < 0:
+    if current_value < 0:
         issues.add_issue(hass, "entity_negative_state", entity_id, current_value)
 
     device_class = state.attributes.get(ATTR_DEVICE_CLASS)


### PR DESCRIPTION
Payel Mahapatra, Group 4
## Proposed Change
### Code Smell Issue Prioritized and Motivation 
This pull request aims to fix the code smell "Comparison to None should not be constant". The issue that was prioritised to be fixed is in `_async_validate_usage_stat(...)` of `homeassistant/components/energy/validate.py` at Line Number 198. 

This code smell states that a variable should be checked for None values only at that point in the code when we are certain that a None value may exist. If a None value is not possible, then it only raises confusion when we give a condition to check for its availability. It makes this check redundant or denotes there is a bug that enables the variable to have a None value.

This issue for this type of code smell was prioritised from a total of 33 similar issues because it conformed to our prioritization criteria. Our prioritization criteria stated that any issue that had a long code smell persistence age of 4-6 years needed urgent attention and the files that had  more number of commits and higher cyclomatic complexity were considered vulnerable and in need of refactoring. We also gave code smells that existed in test packages and test files less priority because code from test packages do not reach production. This particular issue that I worked on was observed to have persisted for 4 years which was significantly higher compared to the other issues and the file has a cyclomatic complexity of 60 with the number of commits being 37. Issues that are kept unaddressed for a longer time tend to become part of the code and more similar issues can crop up due to bad code writing practices.

### Chosen Issue Description and Fix Applied
In this particular issue ([Remove this identity check; it will always be True] L198), it can be seen `current_value` cannot have a value `None` at that point in code. Just before this check has been put in place, there is a try block that handles exceptions when the value for `current_value` is passed non numeric. So even if a None value was assigned to `current_value` it would have been caught in the try block and an exception would have been thrown. So the check at line 198 becomes redundant.

The easy fix is to remove this condition check for `None` value. So the condition becomes `current_value < 0:` However, upon trying that, I observed an error during running pre-commit checks from `mypy`. It says `Unsupported operand types for > ("int" and "None")
[operator]`. Image below shows the error. This happens because python wants to keep the check for None in place. This is because during declaration, it is specified `current_value` can have both `float` and `None` value. This type hinting is not necessary as non numeric value is not desired according to the existing code logic. So to remove our code smell, I declared `current_value` to have value type  as only `float`. So even if a None value does appear for it, it will be handled in the try block and exception raised, like desired.

<img width="733" height="514" alt="Image3" src="https://github.com/user-attachments/assets/68bc4e3b-ac8c-4303-a8da-bfda073e7759" />




The issue is therefore fixed. Image below shows all the pre-commit checks,  including `mypy` passing. I ran `pytest` for this component and ensured all test cases pass after the issue fix with no break in existing code.

<img width="741" height="512" alt="Image2" src="https://github.com/user-attachments/assets/d06d9f95-b1f2-4ac0-80f6-deb2c0a40d5c" />

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->
This change removes a comparison to a None value of a variable when that variable cannot have a None value at that point in code.
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests
## Additional information
### Updated Quality Scan Report
Old Report of Code Smell screenshot:
<img width="1370" height="754" alt="Image4" src="https://github.com/user-attachments/assets/3909b0d7-8dea-4402-9d11-e34cd6f1d8ea" />


Updated Quality Scan Report shows number of issues reduced from 33 to 32 and the code smell removed. It also shows that the cyclomatic complexity of the file has been reduced from 60 to 59.
https://sonarcloud.io/project/issues?impactSeverities=HIGH&rules=python%3AS5727&severities=CRITICAL&issueStatuses=OPEN%2CCONFIRMED&types=CODE_SMELL&id=PayelMahapatr_home-assistant-core-ht25

When I try to access the link to the old code smell in the previous Sonar Cloud Scans, it now shows it cannot open the issue as it does not exist anymore.
https://sonarcloud.io/project/issues?impactSeverities=HIGH&rules=python%3AS5727&severities=CRITICAL&issueStatuses=OPEN%2CCONFIRMED&types=CODE_SMELL&id=PayelMahapatr_home-assistant-core-ht25&open=AZl33mry7ZH5Y9UwTE14