### PR TITLE
Fix: avoid float equality check in binary_sensor.py using math.isclose

### DIFF
--- a/homeassistant/components/android_ip_webcam/binary_sensor.py
+++ b/homeassistant/components/android_ip_webcam/binary_sensor.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from math import isclose
+
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
     BinarySensorEntity,
@@ -53,4 +55,5 @@ class IPWebcamBinarySensor(AndroidIPCamBaseEntity, BinarySensorEntity):
     @property
     def is_on(self) -> bool:
         """Return if motion is detected."""
-        return self.cam.get_sensor_value(MOTION_ACTIVE) == 1.0
+        value = self.cam.get_sensor_value(MOTION_ACTIVE)
+        return isclose(value, 1.0, rel_tol=1e-09, abs_tol=1e-06)


### PR DESCRIPTION
Name: Zahanat Ali Khan
Group 15
Code Smell: Floating point numbers should not be tested for equality.

While reviewing the code using tools such as SonarQube, I noticed that the binary sensor checks for motion by testing if a sensor value is exactly equal to 1.0. Comparing floating point numbers this way can be unreliable, since even very small precision differences could cause the check to fail.
To make the code more robust, I replaced the equality check with math.isclose. This method allows for safe float comparisons within a small tolerance, which is a better fit for sensor readings that may not always come back as a perfectly exact 1.0.
With this change, motion detection will be less error-prone and the code is easier to maintain in the long run.