### PR TITLE
Fix duplicate string "node removed" from homeassistant/components/zwave_js/api.py

### DIFF
--- a/homeassistant/components/zwave_js/api.py
+++ b/homeassistant/components/zwave_js/api.py
@@ -188,6 +188,9 @@ AREA_ID = "area_id"
 FEATURE = "feature"
 STRATEGY = "strategy"
 
+# constants for messages
+REMOVE_NODE = "node removed"
+
 # https://github.com/zwave-js/node-zwave-js/blob/master/packages/core/src/security/QR.ts#L41
 MINIMUM_QR_STRING_LENGTH = 52
 
@@ -1442,7 +1445,7 @@ async def websocket_remove_node(
 
         connection.send_message(
             websocket_api.event_message(
-                msg[ID], {"event": "node removed", "node": node_details}
+                msg[ID], {"event": REMOVE_NODE, "node": node_details}
             )
         )
 
@@ -1451,7 +1454,7 @@ async def websocket_remove_node(
         controller.on("exclusion started", forward_event),
         controller.on("exclusion failed", forward_event),
         controller.on("exclusion stopped", forward_event),
-        controller.on("node removed", node_removed),
+        controller.on(REMOVE_NODE, node_removed),
     ]
 
     result = await controller.async_begin_exclusion(msg.get(STRATEGY))
@@ -1588,7 +1591,7 @@ async def websocket_replace_failed_node(
 
         connection.send_message(
             websocket_api.event_message(
-                msg[ID], {"event": "node removed", "node": node_details}
+                msg[ID], {"event": REMOVE_NODE, "node": node_details}
             )
         )
 
@@ -1613,7 +1616,7 @@ async def websocket_replace_failed_node(
         controller.on("inclusion stopped", forward_event),
         controller.on("validate dsk and enter pin", forward_dsk),
         controller.on("grant security classes", forward_requested_grant),
-        controller.on("node removed", node_removed),
+        controller.on(REMOVE_NODE, node_removed),
         controller.on("node found", node_found),
         controller.on("node added", node_added),
         async_dispatcher_connect(
@@ -1676,12 +1679,12 @@ async def websocket_remove_failed_node(
 
         connection.send_message(
             websocket_api.event_message(
-                msg[ID], {"event": "node removed", "node": node_details}
+                msg[ID], {"event": REMOVE_NODE, "node": node_details}
             )
         )
 
     connection.subscriptions[msg["id"]] = async_cleanup
-    msg[DATA_UNSUBSCRIBE] = unsubs = [controller.on("node removed", node_removed)]
+    msg[DATA_UNSUBSCRIBE] = unsubs = [controller.on(REMOVE_NODE, node_removed)]
 
     await controller.async_remove_failed_node(node)
     connection.send_result(msg[ID])


### PR DESCRIPTION
Maxime LINDEN

**Issue**

Fix six instances of the duplicated string "node remove"

**Motivation**

This issue was prioritized to reduce risks of inconsistency in the file, even if it the issue is not recent  (it was introduced four years ago), because it was the one with the most instances of the same string. Moreover, this issue was also prioritized because the refactoring requires minimal effort, impacting only 6 lines of code with very low complexity. Through this fix, a long-standing (more than a year) issue is removed, and the file gains in readability as well as maintainability.

**Solution** 

To address the issue of the duplicated string, a variable was defined at the beginning of the file to store the content of the string. Then, all instances of the string spread across the file were replaced by the variable, thus making any change uniform.

**Test results**

After refactoring, all the tests keep passing.
<img width="1560" height="242" alt="image" src="https://github.com/user-attachments/assets/cc130ae0-9585-44e4-acc9-b88d1455dded" />
