### PR TITLE
Fixed cognitive complexity of validate_entity_config in Homekit Integration

### DIFF
--- a/homeassistant/components/homekit/util.py
+++ b/homeassistant/components/homekit/util.py
@@ -336,46 +336,39 @@ def validate_entity_config(values: dict) -> dict[str, dict]:
         if not isinstance(config, dict):
             raise vol.Invalid(f"The configuration for {entity} must be a dictionary.")
 
-        if domain == "alarm_control_panel":
-            config = CODE_SCHEMA(config)
-
-        elif domain == media_player.const.DOMAIN:
-            config = FEATURE_SCHEMA(config)
-            feature_list = {}
-            for feature in config[CONF_FEATURE_LIST]:
-                params = MEDIA_PLAYER_SCHEMA(feature)
-                key = params.pop(CONF_FEATURE)
-                if key in feature_list:
-                    raise vol.Invalid(f"A feature can be added only once for {entity}")
-                feature_list[key] = params
-            config[CONF_FEATURE_LIST] = feature_list
-
-        elif domain == "camera":
-            config = CAMERA_SCHEMA(config)
-
-        elif domain == "lock":
-            config = LOCK_SCHEMA(config)
-
-        elif domain == "switch":
-            config = SWITCH_TYPE_SCHEMA(config)
-
-        elif domain == "humidifier":
-            config = HUMIDIFIER_SCHEMA(config)
-
-        elif domain == "cover":
-            config = COVER_SCHEMA(config)
-
-        elif domain == "fan":
-            config = FAN_SCHEMA(config)
-
-        elif domain == "sensor":
-            config = SENSOR_SCHEMA(config)
-
-        elif domain == "valve":
-            config = VALVE_SCHEMA(config)
-
-        else:
-            config = BASIC_INFO_SCHEMA(config)
+        match domain:
+            case media_player.const.DOMAIN:
+                config = FEATURE_SCHEMA(config)
+                feature_list = {}
+                for feature in config[CONF_FEATURE_LIST]:
+                    params = MEDIA_PLAYER_SCHEMA(feature)
+                    key = params.pop(CONF_FEATURE)
+                    if key in feature_list:
+                        raise vol.Invalid(
+                            f"A feature can be added only once for {entity}"
+                        )
+                    feature_list[key] = params
+                config[CONF_FEATURE_LIST] = feature_list
+            case "alarm_control_panel":
+                config = CODE_SCHEMA(config)
+            case "camera":
+                config = CAMERA_SCHEMA(config)
+            case "lock":
+                config = LOCK_SCHEMA(config)
+            case "switch":
+                config = SWITCH_TYPE_SCHEMA(config)
+            case "humidifier":
+                config = HUMIDIFIER_SCHEMA(config)
+            case "cover":
+                config = COVER_SCHEMA(config)
+            case "fan":
+                config = FAN_SCHEMA(config)
+            case "sensor":
+                config = SENSOR_SCHEMA(config)
+            case "valve":
+                config = VALVE_SCHEMA(config)
+            case _:
+                config = BASIC_INFO_SCHEMA(config)
 
         entities[entity] = config
     return entities


### PR DESCRIPTION
Arno Lécrivain
Group 5

### Issue

Refactor this function to reduce its Cognitive Complexity from 23 to the 15 allowed.

### Motivation

This issue was prioritized to improve the file's readability and maintainability. Although this issue is quite recent, the fix is small, low-risk, and straightforward to apply.

### Resolution

This issue was fixed by replacing the long sequence of `if/elif` conditions on `domain` with a `match` statement.  
This reduced the cognitive complexity to the allowed threshold (15) and made the branching logic clearer.

### Tests

All existing tests continue to pass after refactoring.
<img width="1571" height="228" alt="Cognitive_complexity_tests" src="https://github.com/user-attachments/assets/16c083be-32b7-4bde-a956-a4f999ac389a" />

