### PR TITLE
Reduced cognitive complexity in analytics/analytics.py for the function async_devices_payload().

### DIFF
--- a/homeassistant/components/analytics/analytics.py
+++ b/homeassistant/components/analytics/analytics.py
@@ -445,7 +445,7 @@ async def async_devices_payload(hass: HomeAssistant) -> dict:
     #         if device_info["via_device"] is None:
     #             continue
     #         device_info["via_device"] = device_id_mapping.get(device_info["via_device"])
-    check_intinfo(integrations_info, device_id_mapping)
+    integration_info = check_intinfo(integrations_info, device_id_mapping)
     ent_reg = er.async_get(hass)
 
     for entity_entry in ent_reg.entities.values():
@@ -503,7 +503,7 @@ async def async_devices_payload(hass: HomeAssistant) -> dict:
     #             integration_info["custom_integration_version"] = str(
     #                 integration.version
     #             )
-    domain_check(integrations, integrations_info)
+    integrations_info = domain_check(integrations, integrations_info)
 
     return {
         "version": "home-assistant:1",
@@ -515,18 +515,19 @@ async def async_devices_payload(hass: HomeAssistant) -> dict:
 def check_intinfo(
     integrations_info: dict[str, dict[str, Any]],
     device_id_mapping: dict[str, tuple[str, int]],
-) -> None:
+) -> dict[str, dict[str, Any]]:
     """Checks that device_info and stuff is correct."""
     for integration_info in integrations_info.values():
         for device_info in integration_info["devices"]:
             if device_info["via_device"] is None:
                 continue
             device_info["via_device"] = device_id_mapping.get(device_info["via_device"])
+    return integrations_info
 
 
 def domain_check(
     integrations: dict[str, Integration], integrations_info: dict[str, dict[str, Any]]
-) -> None:
+) -> dict[str, dict[str, Any]]:
     """Makes a domain check."""
     for domain, integration_info in integrations_info.items():
         if integration := integrations.get(domain):
@@ -536,3 +537,4 @@ def domain_check(
                 integration_info["custom_integration_version"] = str(
                     integration.version
                 )
+    return integrations_info

--- a/homeassistant/components/analytics/analytics.py
+++ b/homeassistant/components/analytics/analytics.py
@@ -437,14 +437,15 @@ async def async_devices_payload(hass: HomeAssistant) -> dict:
                 "via_device": device_entry.via_device_id,
             }
         )
+    # Can there be a split here?
 
     # Fill out via_device with new device ids
-    for integration_info in integrations_info.values():
-        for device_info in integration_info["devices"]:
-            if device_info["via_device"] is None:
-                continue
-            device_info["via_device"] = device_id_mapping.get(device_info["via_device"])
-
+    # for integration_info in integrations_info.values():
+    #     for device_info in integration_info["devices"]:
+    #         if device_info["via_device"] is None:
+    #             continue
+    #         device_info["via_device"] = device_id_mapping.get(device_info["via_device"])
+    check_intinfo(integrations_info, device_id_mapping)
     ent_reg = er.async_get(hass)
 
     for entity_entry in ent_reg.entities.values():
@@ -494,6 +495,39 @@ async def async_devices_payload(hass: HomeAssistant) -> dict:
         if isinstance(integration, Integration)
     }
 
+    # for domain, integration_info in integrations_info.items():
+    #     if integration := integrations.get(domain):
+    #         integration_info["is_custom_integration"] = not integration.is_built_in
+    #         # Include version for custom integrations
+    #         if not integration.is_built_in and integration.version:
+    #             integration_info["custom_integration_version"] = str(
+    #                 integration.version
+    #             )
+    domain_check(integrations, integrations_info)
+
+    return {
+        "version": "home-assistant:1",
+        "home_assistant": HA_VERSION,
+        "integrations": integrations_info,
+    }
+
+
+def check_intinfo(
+    integrations_info: dict[str, dict[str, Any]],
+    device_id_mapping: dict[str, tuple[str, int]],
+) -> None:
+    """Checks that device_info and stuff is correct."""
+    for integration_info in integrations_info.values():
+        for device_info in integration_info["devices"]:
+            if device_info["via_device"] is None:
+                continue
+            device_info["via_device"] = device_id_mapping.get(device_info["via_device"])
+
+
+def domain_check(
+    integrations: dict[str, Integration], integrations_info: dict[str, dict[str, Any]]
+) -> None:
+    """Makes a domain check."""
     for domain, integration_info in integrations_info.items():
         if integration := integrations.get(domain):
             integration_info["is_custom_integration"] = not integration.is_built_in
@@ -502,9 +536,3 @@ async def async_devices_payload(hass: HomeAssistant) -> dict:
                 integration_info["custom_integration_version"] = str(
                     integration.version
                 )
-
-    return {
-        "version": "home-assistant:1",
-        "home_assistant": HA_VERSION,
-        "integrations": integrations_info,
-    }

--- a/homeassistant/components/analytics/analytics.py
+++ b/homeassistant/components/analytics/analytics.py
@@ -445,7 +445,7 @@ async def async_devices_payload(hass: HomeAssistant) -> dict:
     #         if device_info["via_device"] is None:
     #             continue
     #         device_info["via_device"] = device_id_mapping.get(device_info["via_device"])
-    integration_info = check_intinfo(integrations_info, device_id_mapping)
+    integration_info = fill_via_device(integrations_info, device_id_mapping)
     ent_reg = er.async_get(hass)
 
     for entity_entry in ent_reg.entities.values():
@@ -503,7 +503,7 @@ async def async_devices_payload(hass: HomeAssistant) -> dict:
     #             integration_info["custom_integration_version"] = str(
     #                 integration.version
     #             )
-    integrations_info = domain_check(integrations, integrations_info)
+    integrations_info = version_set(integrations, integrations_info)
 
     return {
         "version": "home-assistant:1",
@@ -512,11 +512,11 @@ async def async_devices_payload(hass: HomeAssistant) -> dict:
     }
 
 
-def check_intinfo(
+def fill_via_device(
     integrations_info: dict[str, dict[str, Any]],
     device_id_mapping: dict[str, tuple[str, int]],
 ) -> dict[str, dict[str, Any]]:
-    """Checks that device_info and stuff is correct."""
+    """Fill out via_device with new device ids."""
     for integration_info in integrations_info.values():
         for device_info in integration_info["devices"]:
             if device_info["via_device"] is None:
@@ -525,10 +525,10 @@ def check_intinfo(
     return integrations_info
 
 
-def domain_check(
+def version_set(
     integrations: dict[str, Integration], integrations_info: dict[str, dict[str, Any]]
 ) -> dict[str, dict[str, Any]]:
-    """Makes a domain check."""
+    """Sets the version for custom integrations."""
     for domain, integration_info in integrations_info.items():
         if integration := integrations.get(domain):
             integration_info["is_custom_integration"] = not integration.is_built_in

--- a/homeassistant/components/apple_tv/config_flow.py
+++ b/homeassistant/components/apple_tv/config_flow.py
@@ -58,6 +58,8 @@ OPTIONS_FLOW = {
     "init": SchemaFlowFormStep(OPTIONS_SCHEMA),
 }
 
+U_EXCEPT = "Unexpected exception"
+
 
 async def device_scan(
     hass: HomeAssistant, identifier: str | None, loop: asyncio.AbstractEventLoop
@@ -189,7 +191,7 @@ class AppleTVConfigFlow(ConfigFlow, domain=DOMAIN):
             except DeviceAlreadyConfigured:
                 errors["base"] = "already_configured"
             except Exception:
-                _LOGGER.exception("Unexpected exception")
+                _LOGGER.exception(U_EXCEPT)
                 errors["base"] = "unknown"
             else:
                 await self.async_set_unique_id(
@@ -333,7 +335,7 @@ class AppleTVConfigFlow(ConfigFlow, domain=DOMAIN):
         except DeviceAlreadyConfigured:
             return self.async_abort(reason="already_configured")
         except Exception:
-            _LOGGER.exception("Unexpected exception")
+            _LOGGER.exception(U_EXCEPT)
             return self.async_abort(reason="unknown")
 
         return await next_func()
@@ -478,7 +480,7 @@ class AppleTVConfigFlow(ConfigFlow, domain=DOMAIN):
             _LOGGER.exception("Authentication problem")
             abort_reason = "invalid_auth"
         except Exception:
-            _LOGGER.exception("Unexpected exception")
+            _LOGGER.exception(U_EXCEPT)
             abort_reason = "unknown"
 
         if abort_reason:
@@ -520,7 +522,7 @@ class AppleTVConfigFlow(ConfigFlow, domain=DOMAIN):
                 _LOGGER.exception("Authentication problem")
                 errors["base"] = "invalid_auth"
             except Exception:
-                _LOGGER.exception("Unexpected exception")
+                _LOGGER.exception(U_EXCEPT)
                 errors["base"] = "unknown"
 
         return self.async_show_form(

--- a/homeassistant/components/vesync/select.py
+++ b/homeassistant/components/vesync/select.py
@@ -45,8 +45,6 @@ HA_TO_VS_HUMIDIFIER_NIGHT_LIGHT_LEVEL_MAP = {
     v: k for k, v in VS_TO_HA_HUMIDIFIER_NIGHT_LIGHT_LEVEL_MAP.items()
 }
 
-ICON = "mdi:brightness-6"
-
 
 @dataclass(frozen=True, kw_only=True)
 class VeSyncSelectEntityDescription(SelectEntityDescription):
@@ -63,7 +61,7 @@ SELECT_DESCRIPTIONS: list[VeSyncSelectEntityDescription] = [
         key="night_light_level",
         translation_key="night_light_level",
         options=list(VS_TO_HA_HUMIDIFIER_NIGHT_LIGHT_LEVEL_MAP.values()),
-        icon=ICON,
+        icon="mdi:brightness-6",
         exists_fn=lambda device: is_humidifier(device) and device.supports_nightlight,
         # The select_option service framework ensures that only options specified are
         # accepted. ServiceValidationError gets raised for invalid value.
@@ -85,7 +83,7 @@ SELECT_DESCRIPTIONS: list[VeSyncSelectEntityDescription] = [
             PURIFIER_NIGHT_LIGHT_LEVEL_DIM,
             PURIFIER_NIGHT_LIGHT_LEVEL_ON,
         ],
-        icon=ICON,
+        icon="mdi:brightness-6",
         exists_fn=lambda device: is_purifier(device) and device.supports_nightlight,
         select_option_fn=lambda device, value: device.set_nightlight_mode(value),
         current_option_fn=lambda device: device.state.nightlight_status,
@@ -99,7 +97,7 @@ SELECT_DESCRIPTIONS: list[VeSyncSelectEntityDescription] = [
             OUTLET_NIGHT_LIGHT_LEVEL_ON,
             OUTLET_NIGHT_LIGHT_LEVEL_AUTO,
         ],
-        icon=ICON,
+        icon="mdi:brightness-6",
         exists_fn=lambda device: is_outlet(device) and device.supports_nightlight,
         select_option_fn=lambda device, value: device.set_nightlight_state(value),
         current_option_fn=lambda device: device.state.nightlight_status,

--- a/homeassistant/components/vesync/select.py
+++ b/homeassistant/components/vesync/select.py
@@ -45,6 +45,8 @@ HA_TO_VS_HUMIDIFIER_NIGHT_LIGHT_LEVEL_MAP = {
     v: k for k, v in VS_TO_HA_HUMIDIFIER_NIGHT_LIGHT_LEVEL_MAP.items()
 }
 
+ICON = "mdi:brightness-6"
+
 
 @dataclass(frozen=True, kw_only=True)
 class VeSyncSelectEntityDescription(SelectEntityDescription):
@@ -61,7 +63,7 @@ SELECT_DESCRIPTIONS: list[VeSyncSelectEntityDescription] = [
         key="night_light_level",
         translation_key="night_light_level",
         options=list(VS_TO_HA_HUMIDIFIER_NIGHT_LIGHT_LEVEL_MAP.values()),
-        icon="mdi:brightness-6",
+        icon=ICON,
         exists_fn=lambda device: is_humidifier(device) and device.supports_nightlight,
         # The select_option service framework ensures that only options specified are
         # accepted. ServiceValidationError gets raised for invalid value.
@@ -83,7 +85,7 @@ SELECT_DESCRIPTIONS: list[VeSyncSelectEntityDescription] = [
             PURIFIER_NIGHT_LIGHT_LEVEL_DIM,
             PURIFIER_NIGHT_LIGHT_LEVEL_ON,
         ],
-        icon="mdi:brightness-6",
+        icon=ICON,
         exists_fn=lambda device: is_purifier(device) and device.supports_nightlight,
         select_option_fn=lambda device, value: device.set_nightlight_mode(value),
         current_option_fn=lambda device: device.state.nightlight_status,
@@ -97,7 +99,7 @@ SELECT_DESCRIPTIONS: list[VeSyncSelectEntityDescription] = [
             OUTLET_NIGHT_LIGHT_LEVEL_ON,
             OUTLET_NIGHT_LIGHT_LEVEL_AUTO,
         ],
-        icon="mdi:brightness-6",
+        icon=ICON,
         exists_fn=lambda device: is_outlet(device) and device.supports_nightlight,
         select_option_fn=lambda device, value: device.set_nightlight_state(value),
         current_option_fn=lambda device: device.state.nightlight_status,


### PR DESCRIPTION
Axel Holswilder

The code smell is important to address because the code should be more modular to then become easier to understand and work with. The more nested statements and loops you have, the denser the function becomes and thus also harder to comprehend. In sonarcloud each function is given a score to represent their complexity, and if it's larger than 15 it triggers the codesmell. Each nested loop or conditional statement adds is worth one extra point to the complexity(so the first if statement is +1, one nested in that is +2, if there's a for loop nested in that it adds another +3, and so on).

The code smell was addressed by taking two for loops with high levels of nesting and moving them to their own two functions which are then called from the async_devices_payload() function. This pushed the score down under 15.

<img width="1252" height="476" alt="Skärmbild 2025-10-03 160707" src="https://github.com/user-attachments/assets/9319b28c-79e8-463f-90f0-ef9f839c0112" />

Image shows the component passing it's tests after the changes.



