### PR TITLE
Refactor bluetooth_le_tracker to reduce cognitive complexity

### DIFF
--- a/homeassistant/components/bluetooth_le_tracker/device_tracker.py
+++ b/homeassistant/components/bluetooth_le_tracker/device_tracker.py
@@ -52,175 +52,257 @@ PLATFORM_SCHEMA = DEVICE_TRACKER_PLATFORM_SCHEMA.extend(
 )
 
 
-async def async_setup_scanner(  # noqa: C901
-    hass: HomeAssistant,
-    config: ConfigType,
-    async_see: AsyncSeeCallback,
-    discovery_info: DiscoveryInfoType | None = None,
-) -> bool:
-    """Set up the Bluetooth LE Scanner."""
+class BLEDeviceTracker:
+    """Manages Bluetooth LE device tracking."""
 
-    new_devices: dict[str, dict] = {}
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        async_see: AsyncSeeCallback,
+        battery_track_interval: timedelta,
+        track_new: bool,
+    ) -> None:
+        """Initialize the BLE device tracker."""
+        self.hass = hass
+        self.async_see = async_see
+        self.battery_track_interval = battery_track_interval
+        self.track_new = track_new
 
-    if config[CONF_TRACK_BATTERY]:
-        battery_track_interval = config[CONF_TRACK_BATTERY_INTERVAL]
-    else:
-        battery_track_interval = timedelta(0)
+        self.new_devices: dict[str, dict] = {}
+        self.devs_to_track: set[str] = set()
+        self.devs_no_track: set[str] = set()
+        self.devs_advertise_time: dict[str, float] = {}
+        self.devs_track_battery: dict[str, datetime] = {}
 
-    yaml_path = hass.config.path(YAML_DEVICES)
-    devs_to_track: set[str] = set()
-    devs_no_track: set[str] = set()
-    devs_advertise_time: dict[str, float] = {}
-    devs_track_battery = {}
-    interval: timedelta = config.get(CONF_SCAN_INTERVAL, SCAN_INTERVAL)
-    # if track new devices is true discover new devices
-    # on every scan.
-    track_new = config.get(CONF_TRACK_NEW)
-
-    async def async_see_device(address, name, new_device=False, battery=None):
+    async def async_see_device(
+        self,
+        address: str,
+        name: str | None,
+        new_device: bool = False,
+        battery: int | None = None,
+    ) -> None:
         """Mark a device as seen."""
         if name is not None:
             name = name.strip("\x00")
 
         if new_device:
-            if address in new_devices:
-                new_devices[address]["seen"] += 1
-                if name:
-                    new_devices[address]["name"] = name
-                else:
-                    name = new_devices[address]["name"]
-                _LOGGER.debug("Seen %s %s times", address, new_devices[address]["seen"])
-                if new_devices[address]["seen"] < MIN_SEEN_NEW:
-                    return
-                _LOGGER.debug("Adding %s to tracked devices", address)
-                devs_to_track.add(address)
-                if battery_track_interval > timedelta(0):
-                    devs_track_battery[address] = dt_util.as_utc(
-                        datetime.fromtimestamp(0)
-                    )
-            else:
-                _LOGGER.debug("Seen %s for the first time", address)
-                new_devices[address] = {"seen": 1, "name": name}
+            should_continue, name = await self._handle_new_device(address, name)
+            if not should_continue:
                 return
 
-        await async_see(
+        await self.async_see(
             mac=BLE_PREFIX + address,
             host_name=name,
             source_type=SourceType.BLUETOOTH_LE,
             battery=battery,
         )
 
-    # Load all known devices.
-    # We just need the devices so set consider_home and home range
-    # to 0
-    for device in await async_load_config(yaml_path, hass, timedelta(0)):
-        # check if device is a valid bluetooth device
-        if device.mac and device.mac[:4].upper() == BLE_PREFIX:
-            address = device.mac[4:]
-            if device.track:
-                _LOGGER.debug("Adding %s to BLE tracker", device.mac)
-                devs_to_track.add(address)
-                if battery_track_interval > timedelta(0):
-                    devs_track_battery[address] = dt_util.as_utc(
-                        datetime.fromtimestamp(0)
-                    )
+    async def _handle_new_device(
+        self, address: str, name: str | None
+    ) -> tuple[bool, str | None]:
+        """Handle a newly discovered device.
+
+        Returns a tuple of (should_continue, name_to_use).
+        """
+        if address in self.new_devices:
+            self.new_devices[address]["seen"] += 1
+            if name:
+                self.new_devices[address]["name"] = name
             else:
-                _LOGGER.debug("Adding %s to BLE do not track", device.mac)
-                devs_no_track.add(address)
+                # Preserve the name from the previous scan
+                name = self.new_devices[address]["name"]
+            _LOGGER.debug(
+                "Seen %s %s times", address, self.new_devices[address]["seen"]
+            )
 
-    if not devs_to_track and not track_new:
-        _LOGGER.warning("No Bluetooth LE devices to track!")
-        return False
+            if self.new_devices[address]["seen"] < MIN_SEEN_NEW:
+                return False, name
 
-    async def _async_see_update_ble_battery(
+            _LOGGER.debug("Adding %s to tracked devices", address)
+            self.add_device_to_track(address)
+            return True, name
+
+        _LOGGER.debug("Seen %s for the first time", address)
+        self.new_devices[address] = {"seen": 1, "name": name}
+        return False, name
+
+    def add_device_to_track(self, address: str) -> None:
+        """Add a device to the tracking list."""
+        self.devs_to_track.add(address)
+        if self.battery_track_interval > timedelta(0):
+            self.devs_track_battery[address] = dt_util.as_utc(datetime.fromtimestamp(0))
+
+    async def async_update_ble_battery(
+        self,
         mac: str,
         now: datetime,
         service_info: bluetooth.BluetoothServiceInfoBleak,
     ) -> None:
-        """Lookup Bluetooth LE devices and update status."""
-        battery = None
-        # We need one we can connect to since the tracker will
-        # accept devices from non-connectable sources
-        if service_info.connectable:
-            device = service_info.device
-        elif connectable_device := bluetooth.async_ble_device_from_address(
-            hass, service_info.device.address, True
-        ):
-            device = connectable_device
-        else:
-            # The device can be seen by a passive tracker but we
-            # don't have a route to make a connection
+        """Lookup Bluetooth LE devices and update battery status."""
+        device = self._get_connectable_device(service_info)
+        if device is None:
             return
+
+        battery = await self._read_battery_level(device, service_info.name, mac)
+        if battery:
+            await self.async_see_device(mac, service_info.name, battery=battery)
+
+    def _get_connectable_device(
+        self, service_info: bluetooth.BluetoothServiceInfoBleak
+    ):
+        """Get a connectable device from service info."""
+        if service_info.connectable:
+            return service_info.device
+
+        connectable_device = bluetooth.async_ble_device_from_address(
+            self.hass, service_info.device.address, True
+        )
+        if connectable_device:
+            return connectable_device
+
+        # The device can be seen by a passive tracker but we
+        # don't have a route to make a connection
+        return None
+
+    async def _read_battery_level(
+        self, device, device_name: str, mac: str
+    ) -> int | None:
+        """Read battery level from a BLE device."""
         try:
             async with BleakClient(device) as client:
                 bat_char = await client.read_gatt_char(BATTERY_CHARACTERISTIC_UUID)
-                battery = ord(bat_char)
+                return ord(bat_char)
         except TimeoutError:
             _LOGGER.debug(
-                "Timeout when trying to get battery status for %s", service_info.name
+                "Timeout when trying to get battery status for %s", device_name
             )
-        # Bleak currently has a few places where checking dbus attributes
-        # can raise when there is another error. We need to trap AttributeError
-        # until bleak releases v0.15+ which resolves these.
         except (AttributeError, BleakError) as err:
             _LOGGER.debug("Could not read battery status: %s", err)
             # If the device does not offer battery information, there is no point in asking again later on.
             # Remove the device from the battery-tracked devices, so that their battery is not wasted
             # trying to get an unavailable information.
-            del devs_track_battery[mac]
-        if battery:
-            await async_see_device(mac, service_info.name, battery=battery)
+            if mac in self.devs_track_battery:
+                del self.devs_track_battery[mac]
+        return None
 
     @callback
-    def _async_update_ble(
+    def async_update_ble(
+        self,
         service_info: bluetooth.BluetoothServiceInfoBleak,
         change: bluetooth.BluetoothChange,
     ) -> None:
         """Update from a ble callback."""
         mac = service_info.address
-        if mac in devs_to_track:
-            devs_advertise_time[mac] = service_info.time
-            now = dt_util.utcnow()
-            hass.async_create_task(async_see_device(mac, service_info.name))
-            if (
-                mac in devs_track_battery
-                and now > devs_track_battery[mac] + battery_track_interval
-            ):
-                devs_track_battery[mac] = now
-                hass.async_create_background_task(
-                    _async_see_update_ble_battery(mac, now, service_info),
-                    "bluetooth_le_tracker.device_tracker-see_update_ble_battery",
-                )
 
-        if track_new:
-            if mac not in devs_to_track and mac not in devs_no_track:
-                _LOGGER.debug("Discovered Bluetooth LE device %s", mac)
-                hass.async_create_task(
-                    async_see_device(mac, service_info.name, new_device=True)
-                )
+        if mac in self.devs_to_track:
+            self._handle_tracked_device(mac, service_info)
+
+        if (
+            self.track_new
+            and mac not in self.devs_to_track
+            and mac not in self.devs_no_track
+        ):
+            self._handle_discovered_device(mac, service_info)
+
+    def _handle_tracked_device(
+        self, mac: str, service_info: bluetooth.BluetoothServiceInfoBleak
+    ) -> None:
+        """Handle updates for a tracked device."""
+        self.devs_advertise_time[mac] = service_info.time
+        now = dt_util.utcnow()
+        self.hass.async_create_task(self.async_see_device(mac, service_info.name))
+
+        if self._should_update_battery(mac, now):
+            self.devs_track_battery[mac] = now
+            self.hass.async_create_background_task(
+                self.async_update_ble_battery(mac, now, service_info),
+                "bluetooth_le_tracker.device_tracker-see_update_ble_battery",
+            )
+
+    def _should_update_battery(self, mac: str, now: datetime) -> bool:
+        """Check if battery should be updated for a device."""
+        return (
+            mac in self.devs_track_battery
+            and now > self.devs_track_battery[mac] + self.battery_track_interval
+        )
+
+    def _handle_discovered_device(
+        self, mac: str, service_info: bluetooth.BluetoothServiceInfoBleak
+    ) -> None:
+        """Handle a newly discovered device."""
+        _LOGGER.debug("Discovered Bluetooth LE device %s", mac)
+        self.hass.async_create_task(
+            self.async_see_device(mac, service_info.name, new_device=True)
+        )
 
     @callback
-    def _async_refresh_ble(now: datetime) -> None:
+    def async_refresh_ble(self, now: datetime) -> None:
         """Refresh BLE devices from the discovered service info."""
         # Make sure devices are seen again at the scheduled
         # interval so they do not get set to not_home when
         # there have been no callbacks because the RSSI or
         # other properties have not changed.
-        for service_info in bluetooth.async_discovered_service_info(hass, False):
-            # Only call _async_update_ble if the advertisement time has changed
-            if service_info.time != devs_advertise_time.get(service_info.address):
-                _async_update_ble(service_info, bluetooth.BluetoothChange.ADVERTISEMENT)
+        for service_info in bluetooth.async_discovered_service_info(self.hass, False):
+            # Only call async_update_ble if the advertisement time has changed
+            if service_info.time != self.devs_advertise_time.get(service_info.address):
+                self.async_update_ble(
+                    service_info, bluetooth.BluetoothChange.ADVERTISEMENT
+                )
 
+
+async def _load_known_devices(
+    yaml_path: str,
+    hass: HomeAssistant,
+    tracker: BLEDeviceTracker,
+) -> None:
+    """Load all known devices from configuration."""
+    for device in await async_load_config(yaml_path, hass, timedelta(0)):
+        if not device.mac or device.mac[:4].upper() != BLE_PREFIX:
+            continue
+
+        address = device.mac[4:]
+        if device.track:
+            _LOGGER.debug("Adding %s to BLE tracker", device.mac)
+            tracker.add_device_to_track(address)
+        else:
+            _LOGGER.debug("Adding %s to BLE do not track", device.mac)
+            tracker.devs_no_track.add(address)
+
+
+async def async_setup_scanner(
+    hass: HomeAssistant,
+    config: ConfigType,
+    async_see: AsyncSeeCallback,
+    discovery_info: DiscoveryInfoType | None = None,
+) -> bool:
+    """Set up the Bluetooth LE Scanner."""
+    battery_track_interval = (
+        config[CONF_TRACK_BATTERY_INTERVAL]
+        if config[CONF_TRACK_BATTERY]
+        else timedelta(0)
+    )
+    track_new = bool(config.get(CONF_TRACK_NEW))
+    interval: timedelta = config.get(CONF_SCAN_INTERVAL, SCAN_INTERVAL)
+
+    tracker = BLEDeviceTracker(hass, async_see, battery_track_interval, track_new)
+
+    # Load all known devices
+    yaml_path = hass.config.path(YAML_DEVICES)
+    await _load_known_devices(yaml_path, hass, tracker)
+
+    if not tracker.devs_to_track and not track_new:
+        _LOGGER.warning("No Bluetooth LE devices to track!")
+        return False
+
+    # Register callbacks
     cancels = [
         bluetooth.async_register_callback(
             hass,
-            _async_update_ble,
-            BluetoothCallbackMatcher(
-                connectable=False
-            ),  # We will take data from any source
+            tracker.async_update_ble,
+            BluetoothCallbackMatcher(connectable=False),
             bluetooth.BluetoothScanningMode.ACTIVE,
         ),
-        async_track_time_interval(hass, _async_refresh_ble, interval),
+        async_track_time_interval(hass, tracker.async_refresh_ble, interval),
     ]
 
     @callback
@@ -231,6 +313,6 @@ async def async_setup_scanner(  # noqa: C901
 
     hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, _async_handle_stop)
 
-    _async_refresh_ble(dt_util.now())
+    tracker.async_refresh_ble(dt_util.now())
 
     return True


### PR DESCRIPTION
Samuel Lindén

#### Problem
The async_setup_scanner function in homeassistant/components/bluetooth_le_tracker/device_tracker.py had extremely high cognitive complexity:

  - Function contained 3 deeply nested functions with closure over multiple shared variables
  - Mixed concerns: device initialization, battery tracking, callback handling, and state management
  - 182 lines of complex, hard-to-understand code
  - Required # noqa: C901 comment to suppress complexity warnings

  This made the code:
  - Difficult to understand and maintain
  - Hard to test individual components in isolation
  - Prone to bugs due to shared mutable state
  - Challenging for new contributors to modify

#### Solution
Refactored the monolithic function by extracting logic into a well-structured BLEDeviceTracker class:

  1. Created BLEDeviceTracker class - Encapsulates all device tracking state and behavior
  2. Extracted nested functions - Converted to focused methods with single responsibilities:
     * async_see_device - Handle device detection
     * _handle_new_device - Process newly discovered devices
     * add_device_to_track - Add devices to tracking list
     * async_update_ble_battery - Battery status updates
     * _get_connectable_device - Device connection logic
     * _read_battery_level - Battery reading logic
     * async_update_ble - Bluetooth callback handler
     * _handle_tracked_device - Known device updates
     * _should_update_battery - Battery update timing
     * _handle_discovered_device - New device discovery
     * async_refresh_ble - Periodic refresh logic
  4. Added helper function - _load_known_devices for device initialization
  5. Simplified setup function - async_setup_scanner now just coordinates initialization
