### PR TITLE
Remove commented-out code from homekit_controller sensor

### DIFF
--- a/homeassistant/components/homekit_controller/sensor.py
+++ b/homeassistant/components/homekit_controller/sensor.py
@@ -522,9 +522,6 @@ class HomeKitBatterySensor(HomeKitSensor):
     @property
     def is_charging(self) -> bool:
         """Return true if currently charging."""
-        # 0 = not charging
-        # 1 = charging
-        # 2 = not chargeable
         return self.service.value(CharacteristicsTypes.CHARGING_STATE) == 1
 
     @property


### PR DESCRIPTION
Jammithri Kotapati
Remove: comments about  # 0 = not charging
- improving code maintainability
- is_charging method still correctly returns True
- The functionality remains unchanged