### PR TITLE
Unused assignments removed

### DIFF
--- a/tests/helpers/test_entity_registry.py
+++ b/tests/helpers/test_entity_registry.py
@@ -4434,7 +4434,7 @@ async def test_subentry(
     with pytest.raises(
         ValueError, match="Config entry mock-id-1 has no subentry bad-subentry-id"
     ):
-        entry = entity_registry.async_get_or_create(
+        entity_registry.async_get_or_create(
             "light",
             "hue",
             "5678",
@@ -4455,7 +4455,7 @@ async def test_subentry(
     with pytest.raises(
         ValueError, match="Config entry mock-id-1 has no subentry bad-subentry-id"
     ):
-        entry = entity_registry.async_get_or_create(
+        entity_registry.async_get_or_create(
             "light",
             "hue",
             "5678",
@@ -4475,7 +4475,7 @@ async def test_subentry(
     with pytest.raises(
         ValueError, match="Can't change config entry without changing subentry"
     ):
-        entry = entity_registry.async_get_or_create(
+        entity_registry.async_get_or_create(
             "light",
             "hue",
             "5678",
@@ -4485,7 +4485,7 @@ async def test_subentry(
     with pytest.raises(
         ValueError, match="Config entry mock-id-2 has no subentry mock-subentry-id-1-2"
     ):
-        entry = entity_registry.async_get_or_create(
+        entity_registry.async_get_or_create(
             "light",
             "hue",
             "5678",


### PR DESCRIPTION
Srija Nandipati

In tests/helpers/test_entity_registry.py, Removed assignment to local variable 'entry'; the value is never used.

Dead stores refer to assignments made to local variables that are subsequently never used or immediately overwritten. Such assignments are unnecessary and don’t contribute to the functionality or clarity of the code. They may even negatively impact performance. Removing them enhances code cleanliness and readability. Even if the unnecessary operations do not do any harm in terms of the program’s correctness, they are - at best - a waste of computing resources.

Tests:

<img width="1482" height="296" alt="Screenshot 2025-10-04 042337" src="https://github.com/user-attachments/assets/f7b91d20-d3c0-42df-84f8-7fabee8b203f" />


