### PR TITLE
Fix type hint in DecryptedBackupStreamer to return AgentBackup

### DIFF
--- a/homeassistant/components/backup/util.py
+++ b/homeassistant/components/backup/util.py
@@ -533,7 +533,7 @@ class _CipherBackupStreamer:
     ) -> None:
         """Initialize."""
         self._workers: list[_CipherWorkerStatus] = []
-        self._backup = backup
+        self._backup: AgentBackup = backup
         self._hass = hass
         self._open_stream = open_stream
         self._password = password


### PR DESCRIPTION


Kalle Engblom

In DecryptedBackupStreamer, the method backup() was annotated to return AgentBackup, but _backup was not explicitly typed. This caused analyzers to see the return value as a generic dataclass instance instead of AgentBackup.

I fixed this by adding an explicit type hint in the constructor:
self._backup: AgentBackup = backup

This ensures backup() always returns the correct type, improving clarity and static analysis reliability.
