### PR TITLE
fix unused argument on _process_webhook_data in reolink component

### DIFF
--- a/homeassistant/components/reolink/host.py
+++ b/homeassistant/components/reolink/host.py
@@ -864,12 +864,12 @@ class ReolinkHost:
             # We want handle_webhook to return as soon as possible
             # so we process the data in the background, this also shields from cancellation
             hass.async_create_background_task(
-                self._process_webhook_data(hass, webhook_id, data),
+                self._process_webhook_data(hass, data),
                 "Process Reolink webhook",
             )
 
     async def _process_webhook_data(
-        self, hass: HomeAssistant, webhook_id: str, data: bytes | None
+        self, hass: HomeAssistant, data: bytes | None
     ) -> None:
         """Process the data from the Reolink webhook."""
         # This task is executed in the background so we need to catch exceptions


### PR DESCRIPTION
Héloïse HAVY

MOTIVATION

This issue was of the code smell : Unused function parameters should be removed. I choose this example because it increase the readability by removing a parameter not used. Moreover very few number of refactoring actions are necessary so I can see exactly where I am going while fixing it.
It is also almost the only one of this code smell which can be fixed, because all the other ones addressed by sonarQube are due to home assistant architecture.

RESOLUTION

The issue was fixed by deleting the parameter both in the function and in the call of the function. 
I think this will solve the problem because it's only removing something useless so I don't take to much risk. Moreover this function is used only by one other function which is in the same file, so we know exactly the code hierarchy.
I have run the test on this component and they all passed so I think the issue is fixed.