### PR TITLE
Zeth Function should not be empty

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,6 +8,8 @@
     "PYTHONASYNCIODEBUG": "1"
   },
   "features": {
+    // Node feature required for Claude Code until fixed https://github.com/anthropics/devcontainer-features/issues/28
+    "ghcr.io/devcontainers/features/node:1": {},
     "ghcr.io/anthropics/devcontainer-features/claude-code:1.0": {},
     "ghcr.io/devcontainers/features/github-cli:1": {}
   },

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -3,8 +3,7 @@ FROM mcr.microsoft.com/vscode/devcontainers/base:debian
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 RUN \
-    curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
-    && apt-get update \
+    apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         # Additional library needed by some tests and accordingly by VScode Tests Discovery
         bluez \

--- a/homeassistant/components/upb/entity.py
+++ b/homeassistant/components/upb/entity.py
@@ -35,6 +35,11 @@ class UpbEntity(Entity):
         return self._upb.is_connected()
 
     def _element_changed(self, element, changeset):
+        """Handle changes to the element.
+
+        This method is called when the element changes. It should be
+        overridden by subclasses to handle the changes.
+        """
         pass
 
     @callback


### PR DESCRIPTION
Zeth Danielsson
Motivation
 Refers to function  _element_changed in homeassistant/components/upb/entity.py
This issue was prioritized because, while it is a very small change (LoC: 1, complexity: 1), the empty function has persisted in the codebase for over a year without explanation. Since there have been no commits in this area for the past six months, the lack of context increases the risk that future contributors will misunderstand whether the function is intentionally empty or accidentally left unfinished. Leaving unexplained empty functions is a code smell because it reduces code clarity and can cause confusion about intended behavior.

Resolution

The issue was addressed by adding a docstring to explicitly document why the function is empty. This ensures that future maintainers have the necessary context and will not mistake it for incomplete work. Since the refactoring effort was very low, this provides a clear improvement to code readability and maintainability with minimal cost.