### PR TITLE
[KNX] Refactor async_step_tunnel to replace nested conditional (fix Conditional Expression)

### DIFF
--- a/homeassistant/components/knx/config_flow.py
+++ b/homeassistant/components/knx/config_flow.py
@@ -307,13 +307,14 @@ class KNXConfigFlow(ConfigFlow, domain=DOMAIN):
                 for tunnel in self._found_tunnels
                 if user_input[CONF_KNX_GATEWAY] == str(tunnel)
             )
-            connection_type = (
-                CONF_KNX_TUNNELING_TCP_SECURE
-                if self._selected_tunnel.tunnelling_requires_secure
-                else CONF_KNX_TUNNELING_TCP
-                if self._selected_tunnel.supports_tunnelling_tcp
-                else CONF_KNX_TUNNELING
-            )
+            # Refactor: avoid nested conditional expression
+            if self._selected_tunnel.tunnelling_requires_secure:
+                connection_type = CONF_KNX_TUNNELING_TCP_SECURE
+            elif self._selected_tunnel.supports_tunnelling_tcp:
+                connection_type = CONF_KNX_TUNNELING_TCP
+            else:
+                connection_type = CONF_KNX_TUNNELING
+
             self.new_entry_data = KNXConfigEntryData(
                 host=self._selected_tunnel.ip_addr,
                 port=self._selected_tunnel.port,


### PR DESCRIPTION
Sanjeeb Rokaya

Issue type: Conditional Expression (Sonar rule python:S3358)  
Location: homeassistant/components/knx/config_flow.py, lines ~307–324 (function `async_step_tunnel`)  

Why this is a relevant smell?
Nested conditional (ternary) expressions reduce readability and make maintenance harder.  
In this case, the expression chose among three `connection_type` constants based on two boolean  
properties of the selected tunnel. Reading and modifying a stacked ternary is error-prone,  
especially for future contributors unfamiliar with KNX tunneling modes.  

What I changed?
I replaced the nested ternary with a straightforward `if / elif / else` block:  

- If `tunnelling_requires_secure`: `CONF_KNX_TUNNELING_TCP_SECURE`  
- `elif supports_tunnelling_tcp`: `CONF_KNX_TUNNELING_TCP`  
- else: `CONF_KNX_TUNNELING`  

Why this solves the problem?
- Removes the nested conditional expression entirely (satisfies S3358).  
- Improves clarity without changing behavior.  
- Keeps variable names and downstream logic unchanged.  

