### PR TITLE
Fix return type hint issue by creating helper with proper hints

### DIFF
--- a/homeassistant/components/backup/util.py
+++ b/homeassistant/components/backup/util.py
@@ -591,9 +591,14 @@ class DecryptedBackupStreamer(_CipherBackupStreamer):
 
     _cipher_func = staticmethod(decrypt_backup)
 
+    def _replace_agentbackup(self, obj: AgentBackup, **changes: Any) -> AgentBackup:
+        return replace(obj, **changes)
+
     def backup(self) -> AgentBackup:
         """Return the decrypted backup."""
-        return replace(self._backup, protected=False, size=self.size())
+        return self._replace_agentbackup(
+            self._backup, protected=False, size=self.size()
+        )
 
 
 class EncryptedBackupStreamer(_CipherBackupStreamer):


### PR DESCRIPTION
Zeth Danielsson
Changes done

I changed the code so that the static type check is consistent with the type at runtime for "AgentBackup". This was done for the backup function.
Why this was done

This issue has been open for 8 months with little recent activity, but it requires only a small refactoring effort (under 20 LOC, low complexity, ~5 minutes of work). Given the low code churn in this area (fewer than 5 commits in the last 6 months, with the last change 5 months ago), addressing it now is low-risk. With a score of 9/18, this fix removes a long-standing type inconsistency and improves code clarity and maintainability with minimal effort.
