### PR TITLE
Fix: remove unused url parameter

### DIFF
--- a/homeassistant/components/blueprint/importer.py
+++ b/homeassistant/components/blueprint/importer.py
@@ -96,7 +96,6 @@ def _get_community_post_import_url(url: str) -> str:
 
 
 def _extract_blueprint_from_community_topic(
-    url: str,
     topic: dict,
 ) -> ImportedBlueprint:
     """Extract a blueprint from a community post JSON.


### PR DESCRIPTION
Issue type: Unused Function Parameter (Sonar rule python:S1172)
Location: homeassistant/components/blueprint/importer.py, line ~99 (function _extract_blueprint_from_community_topic)

**Why this is a relevant smell?**
- Unused parameters in function definitions reduces the code clarity and can mislead contributors into thinking that the argument is required for the logic. In this case, the parameter url: str was defined but never used within the body of _extract_blueprint_from_community_topic. Keeping unused parameters introduces unnecessary complexity and may cause confusion during future maintenance.

**What I changed?**
- I removed the unused parameter url: str from the function signature of _extract_blueprint_from_community_topic.

**Why this solves the problem?**
- Eliminates the unused parameter warning (satisfies S1172 i.e., "No unused parameters").
- Improves code readability and reduces potential confusion.
- Maintains logic integrity, as the parameter was not contributing to any behavior.

**Assignment Mapping**
Student: Bhaskar Nagireddy
Code smell: Unused Parameter