### PR TITLE
fixed cognitive complexity of homeassistance/components/homekit/type_lights.py/async_update_state

### DIFF
--- a/homeassistant/components/homekit/type_lights.py
+++ b/homeassistant/components/homekit/type_lights.py
@@ -40,6 +40,7 @@ from homeassistant.util.color import (
     color_temperature_to_hs,
     color_temperature_to_rgbww,
 )
+from homeassistant.util.read_only_dict import ReadOnlyDict
 
 from .accessories import TYPES, HomeAccessory
 from .const import (
@@ -245,6 +246,76 @@ class Light(HomeAccessory):
         self.async_call_service(LIGHT_DOMAIN, service, params, ", ".join(events))
 
     @callback
+    def async_handle_brightness_on_state_change(
+        self, brightness: float, state: str, color_mode_changed: bool
+    ) -> None:
+        """Update brightness on state change."""
+        # The homeassistant component might report its brightness as 0 but is
+        # not off. But 0 is a special value in homekit. When you turn on a
+        # homekit accessory it will try to restore the last brightness state
+        # which will be the last value saved by char_brightness.set_value.
+        # But if it is set to 0, HomeKit will update the brightness to 100 as
+        # it thinks 0 is off.
+        #
+        # Therefore, if the brightness is 0 and the device is still on,
+        # the brightness is mapped to 1 otherwise the update is ignored in
+        # order to avoid this incorrect behavior.
+        if brightness == 0 and state == STATE_ON:
+            brightness = 1
+        self.char_brightness.set_value(brightness)
+        if color_mode_changed:
+            self.char_brightness.notify()
+
+    @callback
+    def async_handle_color_on_state_change(
+        self,
+        attributes: ReadOnlyDict[str, Any],
+        color_mode: Any | None,
+        color_mode_changed: bool,
+    ) -> None:
+        """Update color on state change."""
+        if color_temp := attributes.get(ATTR_COLOR_TEMP_KELVIN):
+            hue, saturation = color_temperature_to_hs(color_temp)
+        elif color_mode == ColorMode.WHITE:
+            hue, saturation = 0, 0
+        elif (
+            (hue_sat := attributes.get(ATTR_HS_COLOR))
+            and isinstance(hue_sat, (list, tuple))
+            and len(hue_sat) == 2
+        ):
+            hue, saturation = hue_sat
+        else:
+            hue = None
+            saturation = None
+        if isinstance(hue, (int, float)) and isinstance(saturation, (int, float)):
+            self.char_hue.set_value(round(hue, 0))
+            self.char_saturation.set_value(round(saturation, 0))
+            if color_mode_changed:
+                # If the color temp changed, be sure to force the color to update
+                self.char_hue.notify()
+                self.char_saturation.notify()
+
+    @callback
+    def async_handle_white_channels_on_state_change(
+        self,
+        attributes: ReadOnlyDict[str, Any],
+        color_mode: Any,
+        color_mode_changed: bool,
+    ) -> None:
+        """Update white channels on state change."""
+        color_temp: float | None = None
+        if self.color_temp_supported:
+            color_temp_kelvin = attributes.get(ATTR_COLOR_TEMP_KELVIN)
+            if color_temp_kelvin is not None:
+                color_temp = color_temperature_kelvin_to_mired(color_temp_kelvin)
+        elif color_mode == ColorMode.WHITE:
+            color_temp = self.min_mireds
+        if isinstance(color_temp, (int, float)):
+            self.char_color_temp.set_value(round(color_temp, 0))
+            if color_mode_changed:
+                self.char_color_temp.notify()
+
+    @callback
     def async_update_state(self, new_state: State) -> None:
         """Update light after state change."""
         # Handle State
@@ -262,56 +333,19 @@ class Light(HomeAccessory):
             and isinstance(brightness, (int, float))
         ):
             brightness = round(brightness / 255 * 100, 0)
-            # The homeassistant component might report its brightness as 0 but is
-            # not off. But 0 is a special value in homekit. When you turn on a
-            # homekit accessory it will try to restore the last brightness state
-            # which will be the last value saved by char_brightness.set_value.
-            # But if it is set to 0, HomeKit will update the brightness to 100 as
-            # it thinks 0 is off.
-            #
-            # Therefore, if the brightness is 0 and the device is still on,
-            # the brightness is mapped to 1 otherwise the update is ignored in
-            # order to avoid this incorrect behavior.
-            if brightness == 0 and state == STATE_ON:
-                brightness = 1
-            self.char_brightness.set_value(brightness)
-            if color_mode_changed:
-                self.char_brightness.notify()
+            self.async_handle_brightness_on_state_change(
+                brightness, state, color_mode_changed
+            )
 
         # Handle Color - color must always be set before color temperature
         # or the iOS UI will not display it correctly.
         if self.color_supported:
-            if color_temp := attributes.get(ATTR_COLOR_TEMP_KELVIN):
-                hue, saturation = color_temperature_to_hs(color_temp)
-            elif color_mode == ColorMode.WHITE:
-                hue, saturation = 0, 0
-            elif (
-                (hue_sat := attributes.get(ATTR_HS_COLOR))
-                and isinstance(hue_sat, (list, tuple))
-                and len(hue_sat) == 2
-            ):
-                hue, saturation = hue_sat
-            else:
-                hue = None
-                saturation = None
-            if isinstance(hue, (int, float)) and isinstance(saturation, (int, float)):
-                self.char_hue.set_value(round(hue, 0))
-                self.char_saturation.set_value(round(saturation, 0))
-                if color_mode_changed:
-                    # If the color temp changed, be sure to force the color to update
-                    self.char_hue.notify()
-                    self.char_saturation.notify()
+            self.async_handle_color_on_state_change(
+                attributes, color_mode, color_mode_changed
+            )
 
         # Handle white channels
-        if CHAR_COLOR_TEMPERATURE in self.chars:
-            color_temp = None
-            if self.color_temp_supported:
-                color_temp_kelvin = attributes.get(ATTR_COLOR_TEMP_KELVIN)
-                if color_temp_kelvin is not None:
-                    color_temp = color_temperature_kelvin_to_mired(color_temp_kelvin)
-            elif color_mode == ColorMode.WHITE:
-                color_temp = self.min_mireds
-            if isinstance(color_temp, (int, float)):
-                self.char_color_temp.set_value(round(color_temp, 0))
-                if color_mode_changed:
-                    self.char_color_temp.notify()
+
+        self.async_handle_white_channels_on_state_change(
+            attributes, color_mode, color_mode_changed
+        )


### PR DESCRIPTION
Viktor Kalvoda

Rule/Issue: Code smell: 
The cognitive complexity of the function validate_entity_config exceed the limit fixed to 15. This creates an improved complexity for the function whereas there could be just a match.

Motivation:
The chosen method/issue has a high code complexity of 32 and the method is quite split up. For the understanding what the method does its not important to know how exactly the brightness etc. are changed. Therefore here it makes sense to split up the function.

How I have adressed the Issue:
I reduced the code complexity by splittling up the async_update_state function so its handling of brightness, color and color temperature is done in different methods.
 
How that solves the problem:
The code complexity is heavily reduced and you still understand what the method is for without having to dive deeper into it.
<img width="1202" height="416" alt="image_2025-10-04_144401352" src="https://github.com/user-attachments/assets/12e71f7c-d6de-43ff-87a1-33479352e533" />
