### PR TITLE
Fix Empty method by adding docstring explanation

### DIFF
--- a/homeassistant/components/upb/entity.py
+++ b/homeassistant/components/upb/entity.py
@@ -35,7 +35,11 @@ class UpbEntity(Entity):
         return self._upb.is_connected()
 
     def _element_changed(self, element, changeset):
-        pass
+        """Handle changes to the element.
+
+        This method is called when the element changes. It should be
+        overridden by subclasses to handle the changes.
+        """
 
     @callback
     def _element_callback(self, element, changeset):


### PR DESCRIPTION
Zeth Danielsson
Motivation

This issue was prioritized because, while it is a very small change (LoC: 1, complexity: 1), the empty function has persisted in the codebase for over a year without explanation. Since there have been no commits in this area for the past six months, the lack of context increases the risk that future contributors will misunderstand whether the function is intentionally empty or accidentally left unfinished. Leaving unexplained empty functions is a code smell because it reduces code clarity and can cause confusion about intended behavior.

Resolution

The issue was addressed by adding a docstring to explicitly document why the function is empty. This ensures that future maintainers have the necessary context and will not mistake it for incomplete work. Since the refactoring effort was very low, this provides a clear improvement to code readability and maintainability with minimal cost.
