### PR TITLE
duplicate strings replaced

### DIFF
--- a/homeassistant/components/alexa/flash_briefings.py
+++ b/homeassistant/components/alexa/flash_briefings.py
@@ -1,10 +1,11 @@
-"""Support for Alexa skill service end point."""
+"""Support for Alexa Flash Briefing skill service endpoint."""
+
+from __future__ import annotations
 
 import hmac
-from http import HTTPStatus
 import logging
 import uuid
-
+from http import HTTPStatus
 from aiohttp.web_response import StreamResponse
 
 from homeassistant.components import http
@@ -37,7 +38,7 @@ FLASH_BRIEFINGS_API_ENDPOINT = "/api/alexa/flash_briefings/{briefing_id}"
 
 @callback
 def async_setup(hass: HomeAssistant, flash_briefing_config: ConfigType) -> None:
-    """Activate Alexa component."""
+    """Activate the Alexa Flash Briefing component."""
     hass.http.register_view(AlexaFlashBriefingView(hass, flash_briefing_config))
 
 
@@ -49,77 +50,66 @@ class AlexaFlashBriefingView(http.HomeAssistantView):
     name = "api:alexa:flash_briefings"
 
     def __init__(self, hass: HomeAssistant, flash_briefings: ConfigType) -> None:
-        """Initialize Alexa view."""
+        """Initialize the Alexa Flash Briefing view."""
         super().__init__()
         self.flash_briefings = flash_briefings
+
+    def _validate_request(
+        self, request: http.HomeAssistantRequest, briefing_id: str
+    ) -> tuple[bool, tuple[bytes, HTTPStatus] | None]:
+        """Validate request authentication and configuration."""
+        password = request.query.get(API_PASSWORD)
+        if password is None:
+            _LOGGER.error(
+                "No password provided for Alexa flash briefing: %s", briefing_id
+            )
+            return False, (b"", HTTPStatus.UNAUTHORIZED)
+
+        expected_password = self.flash_briefings.get(CONF_PASSWORD)
+        if not expected_password or not hmac.compare_digest(
+            password.encode(), expected_password.encode()
+        ):
+            _LOGGER.error("Wrong password for Alexa flash briefing: %s", briefing_id)
+            return False, (b"", HTTPStatus.UNAUTHORIZED)
+
+        if not isinstance(self.flash_briefings.get(briefing_id), list):
+            _LOGGER.error(
+                "No configured Alexa flash briefing was found for: %s", briefing_id
+            )
+            return False, (b"", HTTPStatus.NOT_FOUND)
+
+        return True, None
+
+    def _resolve_value(self, value):
+        """Render a template value or return it directly."""
+        if isinstance(value, template.Template):
+            return value.async_render(parse_result=False)
+        return value
+
+    def _build_briefing_item(self, item: dict) -> dict:
+        """Build a single Alexa Flash Briefing response item."""
+        output = {
+            ATTR_TITLE_TEXT: self._resolve_value(item.get(CONF_TITLE)),
+            ATTR_MAIN_TEXT: self._resolve_value(item.get(CONF_TEXT)),
+            ATTR_STREAM_URL: self._resolve_value(item.get(CONF_AUDIO)),
+            ATTR_REDIRECTION_URL: self._resolve_value(item.get(CONF_DISPLAY_URL)),
+            ATTR_UID: item.get(CONF_UID) or str(uuid.uuid4()),
+            ATTR_UPDATE_DATE: dt_util.utcnow().strftime(DATE_FORMAT),
+        }
+        return {k: v for k, v in output.items() if v is not None}
 
     @callback
     def get(
         self, request: http.HomeAssistantRequest, briefing_id: str
     ) -> StreamResponse | tuple[bytes, HTTPStatus]:
-        """Handle Alexa Flash Briefing request."""
+        """Handle Alexa Flash Briefing GET requests."""
         _LOGGER.debug("Received Alexa flash briefing request for: %s", briefing_id)
 
-        if request.query.get(API_PASSWORD) is None:
-            err = "No password provided for Alexa flash briefing: %s"
-            _LOGGER.error(err, briefing_id)
-            return b"", HTTPStatus.UNAUTHORIZED
+        valid, error_response = self._validate_request(request, briefing_id)
+        if not valid:
+            return error_response
 
-        if not hmac.compare_digest(
-            request.query[API_PASSWORD].encode("utf-8"),
-            self.flash_briefings[CONF_PASSWORD].encode("utf-8"),
-        ):
-            err = "Wrong password for Alexa flash briefing: %s"
-            _LOGGER.error(err, briefing_id)
-            return b"", HTTPStatus.UNAUTHORIZED
-
-        if not isinstance(self.flash_briefings.get(briefing_id), list):
-            err = "No configured Alexa flash briefing was found for: %s"
-            _LOGGER.error(err, briefing_id)
-            return b"", HTTPStatus.NOT_FOUND
-
-        briefing = []
-
-        for item in self.flash_briefings.get(briefing_id, []):
-            output = {}
-            if item.get(CONF_TITLE) is not None:
-                if isinstance(item.get(CONF_TITLE), template.Template):
-                    output[ATTR_TITLE_TEXT] = item[CONF_TITLE].async_render(
-                        parse_result=False
-                    )
-                else:
-                    output[ATTR_TITLE_TEXT] = item.get(CONF_TITLE)
-
-            if item.get(CONF_TEXT) is not None:
-                if isinstance(item.get(CONF_TEXT), template.Template):
-                    output[ATTR_MAIN_TEXT] = item[CONF_TEXT].async_render(
-                        parse_result=False
-                    )
-                else:
-                    output[ATTR_MAIN_TEXT] = item.get(CONF_TEXT)
-
-            if (uid := item.get(CONF_UID)) is None:
-                uid = str(uuid.uuid4())
-            output[ATTR_UID] = uid
-
-            if item.get(CONF_AUDIO) is not None:
-                if isinstance(item.get(CONF_AUDIO), template.Template):
-                    output[ATTR_STREAM_URL] = item[CONF_AUDIO].async_render(
-                        parse_result=False
-                    )
-                else:
-                    output[ATTR_STREAM_URL] = item.get(CONF_AUDIO)
-
-            if item.get(CONF_DISPLAY_URL) is not None:
-                if isinstance(item.get(CONF_DISPLAY_URL), template.Template):
-                    output[ATTR_REDIRECTION_URL] = item[CONF_DISPLAY_URL].async_render(
-                        parse_result=False
-                    )
-                else:
-                    output[ATTR_REDIRECTION_URL] = item.get(CONF_DISPLAY_URL)
-
-            output[ATTR_UPDATE_DATE] = dt_util.utcnow().strftime(DATE_FORMAT)
-
-            briefing.append(output)
+        items = self.flash_briefings[briefing_id]
+        briefing = [self._build_briefing_item(item) for item in items]
 
         return self.json(briefing)

--- a/homeassistant/components/zwave_js/config_flow.py
+++ b/homeassistant/components/zwave_js/config_flow.py
@@ -72,7 +72,7 @@ from .helpers import (
 from .models import ZwaveJSConfigEntry
 
 _LOGGER = logging.getLogger(__name__)
-
+ERROR_FAILED_USB_PORTS = "Failed to get USB ports: %s"
 DEFAULT_URL = "ws://localhost:3000"
 TITLE = "Z-Wave JS"
 
@@ -747,7 +747,7 @@ class ZWaveJSConfigFlow(ConfigFlow, domain=DOMAIN):
         try:
             ports = await async_get_usb_ports(self.hass)
         except OSError as err:
-            _LOGGER.error("Failed to get USB ports: %s", err)
+            _LOGGER.error(ERROR_FAILED_USB_PORTS, err)
             return self.async_abort(reason="usb_ports_failed")
 
         data_schema = vol.Schema(
@@ -1234,7 +1234,7 @@ class ZWaveJSConfigFlow(ConfigFlow, domain=DOMAIN):
         try:
             ports = await async_get_usb_ports(self.hass)
         except OSError as err:
-            _LOGGER.error("Failed to get USB ports: %s", err)
+            _LOGGER.error(ERROR_FAILED_USB_PORTS, err)
             return self.async_abort(reason="usb_ports_failed")
 
         data_schema = vol.Schema(
@@ -1275,7 +1275,7 @@ class ZWaveJSConfigFlow(ConfigFlow, domain=DOMAIN):
         try:
             ports = await async_get_usb_ports(self.hass)
         except OSError as err:
-            _LOGGER.error("Failed to get USB ports: %s", err)
+            _LOGGER.error(ERROR_FAILED_USB_PORTS, err)
             return self.async_abort(reason="usb_ports_failed")
 
         addon_info = await self._async_get_addon_info()


### PR DESCRIPTION
Anjali Garikapati


Issue

Fixed duplicate strings logger function: Duplicated string literals make the process of refactoring complex and error-prone, as any change would need to be propagated on all occurrences.

Solution: Use constants to replace the duplicated string literals. Constants can be referenced from many places, but only need to be updated in a single place.

Test results
<img width="1060" height="228" alt="Screenshot 2025-10-04 at 14 54 04" src="https://github.com/user-attachments/assets/629a9a5d-1077-40f9-823f-65607fe776d7" />
