### PR TITLE
tests: use math.isclose for float comparisons in MQTT climate tests

### DIFF
--- a/tests/components/mqtt/test_climate.py
+++ b/tests/components/mqtt/test_climate.py
@@ -2,6 +2,7 @@
 
 import copy
 import json
+from math import isclose
 from typing import Any
 from unittest.mock import call, patch
 
@@ -1376,13 +1377,13 @@ async def test_get_target_temperature_low_high_with_templates(
     )
     state = hass.states.get(ENTITY_CLIMATE)
     assert state.attributes.get("target_temp_low") is None
-    assert state.attributes.get("target_temp_high") == 21.0
+    assert isclose(state.attributes.get("target_temp_high"), 21.0)
     async_fire_mqtt_message(
         hass, "temperature-state", '{"temp_low": "18", "temp_high": ""}'
     )
     state = hass.states.get(ENTITY_CLIMATE)
-    assert state.attributes.get("target_temp_low") == 18.0
-    assert state.attributes.get("target_temp_high") == 21.0
+    assert isclose(state.attributes.get("target_temp_low"), 18.0)
+    assert isclose(state.attributes.get("target_temp_high"), 21.0)
     assert "Could not parse temperature_low_state_template from" not in caplog.text
     assert "Could not parse temperature_high_state_template from" not in caplog.text
 


### PR DESCRIPTION
**Name**: Govind Mahadev Banda
**Issue type**: Floating Point Comparison (Sonar rule python:S5044)
Location: tests/components/mqtt/test_climate.py, lines ~1377–1386 (function test_get_target_temperature_low_high_with_templates)

**Why this is a relevant smell?**
Direct equality comparisons between floating-point numbers (e.g., == 21.0) can lead to unreliable test results because of precision differences during calculations. Even small rounding errors can cause equality assertions to fail, especially in computations involving temperature templates or JSON-parsed data. This reduces test robustness and may produce false negatives.

**What I changed**
Replaced the direct equality comparisons with the math.isclose() method for safer and more reliable assertions.

-**Before**
assert state.attributes.get("target_temp_high") == 21.0
assert state.attributes.get("target_temp_low") == 18.0

-**After**
assert isclose(state.attributes.get("target_temp_high"), 21.0)
assert isclose(state.attributes.get("target_temp_low"), 18.0)

**Why this solves the problem?**
-Eliminates the risk of floating-point precision errors in tests (complies with S5044).
-Improves reliability of test results without changing behavior.
-Keeps test readability and logic intact.
-Makes assertions consistent with best practices for numeric comparisons.

**Assignment mapping**
-Code smell: Floating Point Comparison