### PR TITLE
refactor: too many params in assist_pipeline

### DIFF
--- a/homeassistant/components/assist_pipeline/__init__.py
+++ b/homeassistant/components/assist_pipeline/__init__.py
@@ -53,6 +53,7 @@ __all__ = (
     "SAMPLE_WIDTH",
     "AudioSettings",
     "Pipeline",
+    "PipelineConfig",
     "PipelineEvent",
     "PipelineEventType",
     "PipelineNotFound",
@@ -79,58 +80,80 @@ CONFIG_SCHEMA = vol.Schema(
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the Assist pipeline integration."""
     hass.data[DATA_CONFIG] = config.get(DOMAIN, {})
-
-    # wake_word_id -> timestamp of last detection (monotonic_ns)
     hass.data[DATA_LAST_WAKE_UP] = {}
 
     await async_setup_pipeline_store(hass)
     async_register_websocket_api(hass)
-
     return True
+
+
+class PipelineConfig:
+    """Container for pipeline configuration parameters."""
+
+    def __init__(
+        self,
+        *,
+        context: Context,
+        event_callback: PipelineEventCallback,
+        stt_metadata: stt.SpeechMetadata,
+        stt_stream: AsyncIterable[bytes],
+        pipeline_id: str | None = None,
+        conversation_id: str | None = None,
+        tts_audio_output: str | dict[str, Any] | None = None,
+        wake_word_phrase: str | None = None,
+        wake_word_settings: WakeWordSettings | None = None,
+        audio_settings: AudioSettings | None = None,
+        device_id: str | None = None,
+        satellite_id: str | None = None,
+        start_stage: PipelineStage = PipelineStage.STT,
+        end_stage: PipelineStage = PipelineStage.TTS,
+        conversation_extra_system_prompt: str | None = None,
+    ) -> None:
+        """Initialize pipeline configuration parameters."""
+        self.context = context
+        self.event_callback = event_callback
+        self.stt_metadata = stt_metadata
+        self.stt_stream = stt_stream
+        self.pipeline_id = pipeline_id
+        self.conversation_id = conversation_id
+        self.tts_audio_output = tts_audio_output
+        self.wake_word_phrase = wake_word_phrase
+        self.wake_word_settings = wake_word_settings
+        self.audio_settings = audio_settings or AudioSettings()
+        self.device_id = device_id
+        self.satellite_id = satellite_id
+        self.start_stage = start_stage
+        self.end_stage = end_stage
+        self.conversation_extra_system_prompt = conversation_extra_system_prompt
 
 
 async def async_pipeline_from_audio_stream(
     hass: HomeAssistant,
-    *,
-    context: Context,
-    event_callback: PipelineEventCallback,
-    stt_metadata: stt.SpeechMetadata,
-    stt_stream: AsyncIterable[bytes],
-    wake_word_phrase: str | None = None,
-    pipeline_id: str | None = None,
-    conversation_id: str | None = None,
-    tts_audio_output: str | dict[str, Any] | None = None,
-    wake_word_settings: WakeWordSettings | None = None,
-    audio_settings: AudioSettings | None = None,
-    device_id: str | None = None,
-    satellite_id: str | None = None,
-    start_stage: PipelineStage = PipelineStage.STT,
-    end_stage: PipelineStage = PipelineStage.TTS,
-    conversation_extra_system_prompt: str | None = None,
+    config: PipelineConfig,
 ) -> None:
     """Create an audio pipeline from an audio stream.
 
     Raises PipelineNotFound if no pipeline is found.
     """
-    with chat_session.async_get_chat_session(hass, conversation_id) as session:
+    with chat_session.async_get_chat_session(hass, config.conversation_id) as session:
         pipeline_input = PipelineInput(
             session=session,
-            device_id=device_id,
-            satellite_id=satellite_id,
-            stt_metadata=stt_metadata,
-            stt_stream=stt_stream,
-            wake_word_phrase=wake_word_phrase,
-            conversation_extra_system_prompt=conversation_extra_system_prompt,
+            device_id=config.device_id,
+            satellite_id=config.satellite_id,
+            stt_metadata=config.stt_metadata,
+            stt_stream=config.stt_stream,
+            wake_word_phrase=config.wake_word_phrase,
+            conversation_extra_system_prompt=config.conversation_extra_system_prompt,
             run=PipelineRun(
                 hass,
-                context=context,
-                pipeline=async_get_pipeline(hass, pipeline_id=pipeline_id),
-                start_stage=start_stage,
-                end_stage=end_stage,
-                event_callback=event_callback,
-                tts_audio_output=tts_audio_output,
-                wake_word_settings=wake_word_settings,
-                audio_settings=audio_settings or AudioSettings(),
+                context=config.context,
+                pipeline=async_get_pipeline(hass, pipeline_id=config.pipeline_id),
+                start_stage=config.start_stage,
+                end_stage=config.end_stage,
+                event_callback=config.event_callback,
+                tts_audio_output=config.tts_audio_output,
+                wake_word_settings=config.wake_word_settings,
+                audio_settings=config.audio_settings,
             ),
         )
         await pipeline_input.validate()

--- a/homeassistant/components/assist_satellite/entity.py
+++ b/homeassistant/components/assist_satellite/entity.py
@@ -18,6 +18,7 @@ from homeassistant.components import conversation, media_source, stt, tts
 from homeassistant.components.assist_pipeline import (
     OPTION_PREFERRED,
     AudioSettings,
+    PipelineConfig,
     PipelineEvent,
     PipelineEventType,
     PipelineStage,
@@ -508,29 +509,31 @@ class AssistSatelliteEntity(entity.Entity):
                     self.hass,
                     async_pipeline_from_audio_stream(
                         self.hass,
-                        context=self._context,
-                        event_callback=self._internal_on_pipeline_event,
-                        stt_metadata=stt.SpeechMetadata(
-                            language="",  # set in async_pipeline_from_audio_stream
-                            format=stt.AudioFormats.WAV,
-                            codec=stt.AudioCodecs.PCM,
-                            bit_rate=stt.AudioBitRates.BITRATE_16,
-                            sample_rate=stt.AudioSampleRates.SAMPLERATE_16000,
-                            channel=stt.AudioChannels.CHANNEL_MONO,
+                        PipelineConfig(
+                            context=self._context,
+                            event_callback=self._internal_on_pipeline_event,
+                            stt_metadata=stt.SpeechMetadata(
+                                language="",  # set in async_pipeline_from_audio_stream
+                                format=stt.AudioFormats.WAV,
+                                codec=stt.AudioCodecs.PCM,
+                                bit_rate=stt.AudioBitRates.BITRATE_16,
+                                sample_rate=stt.AudioSampleRates.SAMPLERATE_16000,
+                                channel=stt.AudioChannels.CHANNEL_MONO,
+                            ),
+                            stt_stream=audio_stream,
+                            pipeline_id=self._resolve_pipeline(),
+                            conversation_id=session.conversation_id,
+                            device_id=device_id,
+                            satellite_id=self.entity_id,
+                            tts_audio_output=self.tts_options,
+                            wake_word_phrase=wake_word_phrase,
+                            audio_settings=AudioSettings(
+                                silence_seconds=self._resolve_vad_sensitivity()
+                            ),
+                            start_stage=start_stage,
+                            end_stage=end_stage,
+                            conversation_extra_system_prompt=extra_system_prompt,
                         ),
-                        stt_stream=audio_stream,
-                        pipeline_id=self._resolve_pipeline(),
-                        conversation_id=session.conversation_id,
-                        device_id=device_id,
-                        satellite_id=self.entity_id,
-                        tts_audio_output=self.tts_options,
-                        wake_word_phrase=wake_word_phrase,
-                        audio_settings=AudioSettings(
-                            silence_seconds=self._resolve_vad_sensitivity()
-                        ),
-                        start_stage=start_stage,
-                        end_stage=end_stage,
-                        conversation_extra_system_prompt=extra_system_prompt,
                     ),
                     f"{self.entity_id}_pipeline",
                 )

--- a/tests/components/assist_pipeline/test_init.py
+++ b/tests/components/assist_pipeline/test_init.py
@@ -137,8 +137,7 @@ async def test_pipeline_from_audio_stream_legacy(
         "homeassistant.components.tts.secrets.token_urlsafe", return_value="test_token"
     ):
         # Use the created pipeline
-        await assist_pipeline.async_pipeline_from_audio_stream(
-            hass,
+        config = assist_pipeline.PipelineConfig(
             context=Context(),
             event_callback=events.append,
             stt_metadata=stt.SpeechMetadata(
@@ -153,6 +152,7 @@ async def test_pipeline_from_audio_stream_legacy(
             pipeline_id=pipeline_id,
             audio_settings=assist_pipeline.AudioSettings(is_vad_enabled=False),
         )
+        await assist_pipeline.async_pipeline_from_audio_stream(hass, config)
 
     assert process_events(events) == snapshot
     assert len(mock_stt_provider.received) == 2
@@ -205,8 +205,7 @@ async def test_pipeline_from_audio_stream_entity(
         "homeassistant.components.tts.secrets.token_urlsafe", return_value="test_token"
     ):
         # Use the created pipeline
-        await assist_pipeline.async_pipeline_from_audio_stream(
-            hass,
+        config = assist_pipeline.PipelineConfig(
             context=Context(),
             event_callback=events.append,
             stt_metadata=stt.SpeechMetadata(
@@ -221,6 +220,7 @@ async def test_pipeline_from_audio_stream_entity(
             pipeline_id=pipeline_id,
             audio_settings=assist_pipeline.AudioSettings(is_vad_enabled=False),
         )
+        await assist_pipeline.async_pipeline_from_audio_stream(hass, config)
 
     assert process_events(events) == snapshot
     assert len(mock_stt_provider_entity.received) == 2
@@ -270,23 +270,23 @@ async def test_pipeline_from_audio_stream_no_stt(
     pipeline_id = msg["result"]["id"]
 
     # Try to use the created pipeline
+    config = assist_pipeline.PipelineConfig(
+        context=Context(),
+        event_callback=events.append,
+        stt_metadata=stt.SpeechMetadata(
+            language="en-UK",
+            format=stt.AudioFormats.WAV,
+            codec=stt.AudioCodecs.PCM,
+            bit_rate=stt.AudioBitRates.BITRATE_16,
+            sample_rate=stt.AudioSampleRates.SAMPLERATE_16000,
+            channel=stt.AudioChannels.CHANNEL_MONO,
+        ),
+        stt_stream=audio_data(),
+        pipeline_id=pipeline_id,
+        audio_settings=assist_pipeline.AudioSettings(is_vad_enabled=False),
+    )
     with pytest.raises(assist_pipeline.pipeline.PipelineRunValidationError):
-        await assist_pipeline.async_pipeline_from_audio_stream(
-            hass,
-            context=Context(),
-            event_callback=events.append,
-            stt_metadata=stt.SpeechMetadata(
-                language="en-UK",
-                format=stt.AudioFormats.WAV,
-                codec=stt.AudioCodecs.PCM,
-                bit_rate=stt.AudioBitRates.BITRATE_16,
-                sample_rate=stt.AudioSampleRates.SAMPLERATE_16000,
-                channel=stt.AudioChannels.CHANNEL_MONO,
-            ),
-            stt_stream=audio_data(),
-            pipeline_id=pipeline_id,
-            audio_settings=assist_pipeline.AudioSettings(is_vad_enabled=False),
-        )
+        await assist_pipeline.async_pipeline_from_audio_stream(hass, config)
 
     assert not events
 
@@ -310,22 +310,22 @@ async def test_pipeline_from_audio_stream_unknown_pipeline(
         yield b""
 
     # Try to use the created pipeline
+    config = assist_pipeline.PipelineConfig(
+        context=Context(),
+        event_callback=events.append,
+        stt_metadata=stt.SpeechMetadata(
+            language="en-UK",
+            format=stt.AudioFormats.WAV,
+            codec=stt.AudioCodecs.PCM,
+            bit_rate=stt.AudioBitRates.BITRATE_16,
+            sample_rate=stt.AudioSampleRates.SAMPLERATE_16000,
+            channel=stt.AudioChannels.CHANNEL_MONO,
+        ),
+        stt_stream=audio_data(),
+        pipeline_id="blah",
+    )
     with pytest.raises(assist_pipeline.PipelineNotFound):
-        await assist_pipeline.async_pipeline_from_audio_stream(
-            hass,
-            context=Context(),
-            event_callback=events.append,
-            stt_metadata=stt.SpeechMetadata(
-                language="en-UK",
-                format=stt.AudioFormats.WAV,
-                codec=stt.AudioCodecs.PCM,
-                bit_rate=stt.AudioBitRates.BITRATE_16,
-                sample_rate=stt.AudioSampleRates.SAMPLERATE_16000,
-                channel=stt.AudioChannels.CHANNEL_MONO,
-            ),
-            stt_stream=audio_data(),
-            pipeline_id="blah",
-        )
+        await assist_pipeline.async_pipeline_from_audio_stream(hass, config)
 
     assert not events
 
@@ -371,8 +371,7 @@ async def test_pipeline_from_audio_stream_wake_word(
     with patch(
         "homeassistant.components.tts.secrets.token_urlsafe", return_value="test_token"
     ):
-        await assist_pipeline.async_pipeline_from_audio_stream(
-            hass,
+        config = assist_pipeline.PipelineConfig(
             context=Context(),
             event_callback=events.append,
             stt_metadata=stt.SpeechMetadata(
@@ -390,6 +389,7 @@ async def test_pipeline_from_audio_stream_wake_word(
             ),
             audio_settings=assist_pipeline.AudioSettings(is_vad_enabled=False),
         )
+        await assist_pipeline.async_pipeline_from_audio_stream(hass, config)
 
     assert process_events(events) == snapshot
 
@@ -436,8 +436,7 @@ async def test_pipeline_save_audio(
             yield make_10ms_chunk(b"part2")
             yield b""
 
-        await assist_pipeline.async_pipeline_from_audio_stream(
-            hass,
+        config = assist_pipeline.PipelineConfig(
             context=Context(),
             event_callback=events.append,
             stt_metadata=stt.SpeechMetadata(
@@ -454,6 +453,7 @@ async def test_pipeline_save_audio(
             end_stage=assist_pipeline.PipelineStage.STT,
             audio_settings=assist_pipeline.AudioSettings(is_vad_enabled=False),
         )
+        await assist_pipeline.async_pipeline_from_audio_stream(hass, config)
 
         pipeline_dirs = list(temp_dir.iterdir())
 
@@ -524,8 +524,7 @@ async def test_pipeline_saved_audio_with_device_id(
                 code="timeout", message="timeout"
             ),
         ):
-            await assist_pipeline.async_pipeline_from_audio_stream(
-                hass,
+            config = assist_pipeline.PipelineConfig(
                 context=Context(),
                 event_callback=event_callback,
                 stt_metadata=stt.SpeechMetadata(
@@ -541,6 +540,7 @@ async def test_pipeline_saved_audio_with_device_id(
                 end_stage=assist_pipeline.PipelineStage.STT,
                 device_id=device_id,
             )
+            await assist_pipeline.async_pipeline_from_audio_stream(hass, config)
 
 
 async def test_pipeline_saved_audio_write_error(
@@ -574,8 +574,7 @@ async def test_pipeline_saved_audio_write_error(
 
         # Force a timeout during wake word detection
         with patch("wave.Wave_write.writeframes", raises=RuntimeError()):
-            await assist_pipeline.async_pipeline_from_audio_stream(
-                hass,
+            config = assist_pipeline.PipelineConfig(
                 context=Context(),
                 event_callback=event_callback,
                 stt_metadata=stt.SpeechMetadata(
@@ -590,6 +589,7 @@ async def test_pipeline_saved_audio_write_error(
                 start_stage=assist_pipeline.PipelineStage.WAKE_WORD,
                 end_stage=assist_pipeline.PipelineStage.STT,
             )
+            await assist_pipeline.async_pipeline_from_audio_stream(hass, config)
 
 
 async def test_pipeline_saved_audio_empty_queue(
@@ -637,8 +637,7 @@ async def test_pipeline_saved_audio_empty_queue(
             "homeassistant.components.assist_pipeline.pipeline._pipeline_debug_recording_thread_proc",
             proc_wrapper,
         ):
-            await assist_pipeline.async_pipeline_from_audio_stream(
-                hass,
+            config = assist_pipeline.PipelineConfig(
                 context=Context(),
                 event_callback=event_callback,
                 stt_metadata=stt.SpeechMetadata(
@@ -653,6 +652,7 @@ async def test_pipeline_saved_audio_empty_queue(
                 start_stage=assist_pipeline.PipelineStage.WAKE_WORD,
                 end_stage=assist_pipeline.PipelineStage.STT,
             )
+            await assist_pipeline.async_pipeline_from_audio_stream(hass, config)
 
 
 async def test_pipeline_from_audio_stream_with_cloud_auth_fail(
@@ -673,8 +673,7 @@ async def test_pipeline_from_audio_stream_with_cloud_auth_fail(
         "async_process_audio_stream",
         side_effect=hass_nabucasa.auth.Unauthenticated,
     ):
-        await assist_pipeline.async_pipeline_from_audio_stream(
-            hass,
+        config = assist_pipeline.PipelineConfig(
             context=Context(),
             event_callback=events.append,
             stt_metadata=stt.SpeechMetadata(
@@ -688,6 +687,7 @@ async def test_pipeline_from_audio_stream_with_cloud_auth_fail(
             stt_stream=audio_data(),
             audio_settings=assist_pipeline.AudioSettings(is_vad_enabled=False),
         )
+        await assist_pipeline.async_pipeline_from_audio_stream(hass, config)
 
     assert process_events(events) == snapshot
     assert len(events) == 4  # run start, stt start, error, run end

--- a/tests/components/assist_pipeline/test_init.py
+++ b/tests/components/assist_pipeline/test_init.py
@@ -70,8 +70,7 @@ async def test_pipeline_from_audio_stream_auto(
     with patch(
         "homeassistant.components.tts.secrets.token_urlsafe", return_value="test_token"
     ):
-        await assist_pipeline.async_pipeline_from_audio_stream(
-            hass,
+        config = assist_pipeline.PipelineConfig(
             context=Context(),
             event_callback=events.append,
             stt_metadata=stt.SpeechMetadata(
@@ -85,6 +84,7 @@ async def test_pipeline_from_audio_stream_auto(
             stt_stream=audio_data(),
             audio_settings=assist_pipeline.AudioSettings(is_vad_enabled=False),
         )
+        await assist_pipeline.async_pipeline_from_audio_stream(hass, config)
 
     assert process_events(events) == snapshot
     assert len(mock_stt_provider_entity.received) == 2


### PR DESCRIPTION
# Md Shahriar Hasan Parash

**Issue:** `async_pipeline_from_audio_stream` function had 15+ parameters, reducing readability and maintainability.

**Motivation:** 
- Clean, readable function signature
- Better parameter organization  
- Easier to maintain and extend

**Solution:** 
- Created `PipelineConfig` class to encapsulate all parameters
- Reduced function signature from 15+ parameters to just 2: `hass` and `config`
- Updated production code in `assist_satellite/entity.py` to use new API

**Before:**
```python
async_pipeline_from_audio_stream(hass, context=..., event_callback=..., stt_metadata=..., ...)
```

**After:**
```python
config = PipelineConfig(context=..., event_callback=..., stt_metadata=..., ...)
async_pipeline_from_audio_stream(hass, config)
```