### PR TITLE
homematic: remove unused local 'interface_id' (dead store)

### DIFF
--- a/homeassistant/components/homematic/__init__.py
+++ b/homeassistant/components/homematic/__init__.py
@@ -419,8 +419,11 @@ def _system_callback_handler(hass, config, src, *args):
     """System callback handler."""
     # New devices available at hub
     if src == "newDevices":
-        (interface_id, dev_descriptions) = args
-        interface = interface_id.split("-")[-1]
+        # (interface_id, dev_descriptions) = args
+        # interface = interface_id.split("-")[-1]
+
+        _interface_id, dev_descriptions = args
+        interface = _interface_id.split("-")[-1]
 
         # Device support active?
         if not hass.data[DATA_CONF][interface]["connect"]:


### PR DESCRIPTION
Ayomikun Festus-Olaleye Group 4<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This issue was prioritized because dead store variables, which are assigned values but never used, add unnecessary noise to the codebase and negatively impact readability. In this specific case, the variable `interface_id` was defined but never utilized, which made the surrounding code slightly more complicated to follow and maintain. By removing this unused variable, the logic becomes clearer, leaner, and easier for developers to understand. This small change aligns with Home Assistant’s emphasis on maintaining high-quality, maintainable, and efficient code. Eliminating dead stores helps reduce cognitive load during future debugging or refactoring, prevents potential developer confusion, and improves overall code cleanliness. Although minor, such targeted cleanups contribute significantly to the long-term health, reliability, and professionalism of the project, ensuring consistency with established coding best practices.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: *SonarCloud Code Smell – Unused local variable `interface_id`*  
- Related SonarCloud issue:  
  https://sonarcloud.io/project/issues?impactSeverities=MEDIUM&rules=python%3AS1854&severities=MAJOR&issueStatuses=OPEN%2CCONFIRMED&types=CODE_SMELL&id=Mikun07_home-assistant-core-ht25&open=AZmRFVYz2d-msY9OjGN_   