### PR TITLE
Remove commented-out code in esphome media_player

### DIFF
--- a/homeassistant/components/esphome/media_player.py
+++ b/homeassistant/components/esphome/media_player.py
@@ -200,7 +200,6 @@ class EsphomeMediaPlayer(
         device_id = self.device_entry.id
         media_format = format_to_use.format
 
-        # 0 = None
         rate: int | None = None
         channels: int | None = None
         width: int | None = None


### PR DESCRIPTION
Jammithri Kotapati, Group 4

## Motivation

Commented-out code represents a significant maintainability issue that degrades code quality over time. The comment # 0 = None in the ESPHome media player's format handling method serves no functional purpose and creates technical debt. Such dead code comments can confuse developers about the intended behavior, make code reviews more difficult, and clutter the codebase with irrelevant information. In a large project like Home Assistant, maintaining clean, self-documenting code is crucial for developer productivity and long-term maintainability. Removing this type of dead code helps ensure that only meaningful,
purposeful code remains in the repository.

## Solution

I identified and removed the unnecessary comment # 0 = None from the media format handling section in homeassistant/components/esphome/media_player.py at line 203. This solution directly addresses the code smell by eliminating dead code without affecting any functionality. The removal makes the code cleaner and more focused, as the actual variable initialization rate: int | None = None immediately below is self-explanatory and doesn't require the redundant
comment. This approach maintains code clarity while removing the maintenance burden of keeping track of meaningless comments.

## Changes

• Removed comment # 0 = None from media format handling in homeassistant/components/esphome/media_player.py

## Impact

• Improves code maintainability by removing dead code
• Enhances code readability and focus
• No functional changes to the component behavior
• Reduces technical debt in the codebase

## Testing

• Code passes syntax validation
• Linting checks pass (ruff, codespell, prettier)
• No breaking changes introduced
• Existing test suite remains intact (test_media_player.py available)