### PR TITLE
Fix: Clean up _clear_buffer loop to remove empty pass statement

### DIFF
--- a/homeassistant/components/pandora/media_player.py
+++ b/homeassistant/components/pandora/media_player.py
@@ -349,15 +349,11 @@ class PandoraMediaPlayer(MediaPlayerEntity):
         """
         assert self._pianobar is not None
         try:
-            # Continuously expect (read) data until a timeout or EOF occurs.
-            # The result is intentionally ignored as the goal is just to clear the buffer.
-            while True:
-                await self._pianobar.expect(".+", async_=True, timeout=0.1)
+            while not await self._pianobar.expect(".+", async_=True, timeout=0.1):
+                pass
         except pexpect.exceptions.TIMEOUT:
-            # Expected exception when the buffer is finally empty.
             pass
         except pexpect.exceptions.EOF:
-            # Handle if the child process exited during the clear.
             pass
 
 

--- a/homeassistant/components/pandora/media_player.py
+++ b/homeassistant/components/pandora/media_player.py
@@ -349,11 +349,15 @@ class PandoraMediaPlayer(MediaPlayerEntity):
         """
         assert self._pianobar is not None
         try:
-            while not await self._pianobar.expect(".+", async_=True, timeout=0.1):
-                pass
+            # Continuously expect (read) data until a timeout or EOF occurs.
+            # The result is intentionally ignored as the goal is just to clear the buffer.
+            while True:
+                await self._pianobar.expect(".+", async_=True, timeout=0.1)
         except pexpect.exceptions.TIMEOUT:
+            # Expected exception when the buffer is finally empty.
             pass
         except pexpect.exceptions.EOF:
+            # Handle if the child process exited during the clear.
             pass
 
 


### PR DESCRIPTION
# Mihir Singh Thakur, Group 10.
## Code Smell Issue Prioritized and Motivation

There were **sixty-one** issues pertaining to "Nested block of code should not be empty" Code smell, all of which were medium severity and five minute effort fixes.
I simply chose the longest persisted one (nice years), in the 'components' code base.
The issue was in the 'pandora' component, in the file 'media_player.py'.
The method PandoraMediaPlayer._clear_buffer contains a while loop with an empty pass statement:

 try:
    while not await self._pianobar.expect(".+", async_=True, timeout=0.1):
        pass
// ...

This pattern is a code smell (specifically, an empty nested block) and indicates confusing or incomplete logic.

**Confusing Intent**: The use of while not await ...: pass obscures the method's true goal, which is to continuously consume all data in the pexpect buffer until a timeout exception is raised. A successful expect call terminates the while not loop, while a failure (timeout) is intended to be caught by the try...except block outside the loop. The pass is only present to satisfy Python's syntax rules for a non-empty block.

**Maintainability and Readability**: This non-standard construct forces a reader to parse a double negative (while not await...) to understand that the goal is simply to let the loop run until it fails. This makes the code harder to read and maintain.

Addressing this code smell improves the clarity, maintainability, and overall quality of the asynchronous buffer-clearing logic.

## Solution
This Pull Request refactors PandoraMediaPlayer._clear_buffer to use a cleaner while True loop that directly expresses the intent:

try:
    # Continuously expect (read) data until a timeout or EOF occurs.
    while True:
        await self._pianobar.expect(".+", async_=True, timeout=0.1)
except pexpect.exceptions.TIMEOUT:
// ...

This solution solves the problem by:

Removing the empty nested block (pass): The code smell is eliminated.

Improving Clarity: The while True loop clearly states that the code will execute the expect call repeatedly and indefinitely, relying solely on the TIMEOUT or EOF exceptions to terminate the loop and exit the function.

Directly Expressing Intent: The refactored code now directly implements the function's goal: "read from the buffer repeatedly until it times out (is empty)."


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ x] Code quality improvements to existing code or addition of tests

## Additional information
Old Report of Code Smell:
<img width="1440" height="900" alt="Screenshot 2025-10-04 at 5 05 01 PM" src="https://github.com/user-attachments/assets/19b69216-5afc-431b-b421-6863f439dfd4" />
New report with this issue solved:
<img width="1440" height="900" alt="Screenshot 2025-10-04 at 7 23 32 PM" src="https://github.com/user-attachments/assets/6be45425-c8c5-4aab-90b7-cf1b187b7594" />

Updated Quality Scan Report shows number of issues reduced from 61 to 60 and the code smell removed.
