### PR TITLE
Refactor sonos/const.py to remove duplicated string literals

### DIFF
--- a/homeassistant/components/sonos/const.py
+++ b/homeassistant/components/sonos/const.py
@@ -1,5 +1,4 @@
-"""Const for Sonos."""
-
+"""Constants for the Sonos integration."""
 from __future__ import annotations
 
 import datetime
@@ -7,10 +6,11 @@ import datetime
 from homeassistant.components.media_player import MediaClass, MediaType
 from homeassistant.const import Platform
 
-UPNP_ST = "urn:schemas-upnp-org:device:ZonePlayer:1"
-
 DOMAIN = "sonos"
 DATA_SONOS_DISCOVERY_MANAGER = "sonos_discovery_manager"
+
+UPNP_ST = "urn:schemas-upnp-org:device:ZonePlayer:1"
+
 PLATFORMS = [
     Platform.BINARY_SENSOR,
     Platform.MEDIA_PLAYER,
@@ -23,20 +23,45 @@ PLATFORMS = [
 SUB_FAIL_ISSUE_ID = "subscriptions_failed"
 SUB_FAIL_URL = "https://www.home-assistant.io/integrations/sonos/#network-requirements"
 
-SONOS_ARTIST = "artists"
+# Sonos Internal Media Types
 SONOS_ALBUM = "albums"
-SONOS_PLAYLISTS = "playlists"
-SONOS_GENRE = "genres"
 SONOS_ALBUM_ARTIST = "album_artists"
-SONOS_TRACKS = "tracks"
+SONOS_ARTIST = "artists"
+SONOS_AUDIO_BOOK = "audio book"
 SONOS_COMPOSER = "composers"
+SONOS_GENRE = "genres"
+SONOS_OTHER_ITEM = "other items"
+SONOS_PLAYLISTS = "playlists"
 SONOS_RADIO = "radio"
 SONOS_SHARE = "share"
-SONOS_OTHER_ITEM = "other items"
-SONOS_AUDIO_BOOK = "audio book"
+SONOS_TRACKS = "tracks"
 
 MEDIA_TYPE_DIRECTORY = MediaClass.DIRECTORY
 
+# UPnP object types
+UPNP_OBJECT_CONTAINER = "object.container"
+UPNP_OBJECT_ALBUM = "object.container.album.musicAlbum"
+UPNP_OBJECT_GENRE = "object.container.genre.musicGenre"
+UPNP_OBJECT_COMPOSER = "object.container.person.composer"
+UPNP_OBJECT_ARTIST = "object.container.person.musicArtist"
+UPNP_OBJECT_PLAYLIST_CONTAINER = "object.container.playlistContainer"
+UPNP_OBJECT_PLAYLIST_SAME_ARTIST = "object.container.playlistContainer.sameArtist"
+UPNP_OBJECT_ITEM = "object.item"
+UPNP_OBJECT_TRACK = "object.item.audioItem.musicTrack"
+UPNP_OBJECT_BROADCAST = "object.item.audioItem.audioBroadcast"
+UPNP_OBJECT_AUDIOBOOK = "object.item.audioItem.audioBook"
+
+# Sonos Library keys
+LIB_KEY_ALBUM = "A:ALBUM"
+LIB_KEY_ALBUM_ARTIST = "A:ALBUMARTIST"
+LIB_KEY_ARTIST = "A:ARTIST"
+LIB_KEY_COMPOSER = "A:COMPOSER"
+LIB_KEY_GENRE = "A:GENRE"
+LIB_KEY_PLAYLISTS = "A:PLAYLISTS"
+LIB_KEY_TRACKS = "A:TRACKS"
+LIB_KEY_FOLDERS = "S:"
+
+# Sonos States
 SONOS_STATE_PLAYING = "PLAYING"
 SONOS_STATE_TRANSITIONING = "TRANSITIONING"
 
@@ -56,6 +81,17 @@ EXPANDABLE_MEDIA_TYPES = [
     SONOS_SHARE,
 ]
 
+PLAYABLE_MEDIA_TYPES = [
+    MediaType.ALBUM,
+    MediaType.ARTIST,
+    MediaType.COMPOSER,
+    MediaType.CONTRIBUTING_ARTIST,
+    MediaType.GENRE,
+    MediaType.PLAYLIST,
+    MediaType.TRACK,
+]
+
+# Mappings
 SONOS_TO_MEDIA_CLASSES = {
     SONOS_ALBUM: MediaClass.ALBUM,
     SONOS_ALBUM_ARTIST: MediaClass.ARTIST,
@@ -65,17 +101,17 @@ SONOS_TO_MEDIA_CLASSES = {
     SONOS_PLAYLISTS: MediaClass.PLAYLIST,
     SONOS_TRACKS: MediaClass.TRACK,
     SONOS_SHARE: MediaClass.DIRECTORY,
-    "object.container": MediaClass.DIRECTORY,
-    "object.container.album.musicAlbum": MediaClass.ALBUM,
-    "object.container.genre.musicGenre": MediaClass.PLAYLIST,
-    "object.container.person.composer": MediaClass.PLAYLIST,
-    "object.container.person.musicArtist": MediaClass.ARTIST,
-    "object.container.playlistContainer.sameArtist": MediaClass.ARTIST,
-    "object.container.playlistContainer": MediaClass.PLAYLIST,
-    "object.item": MediaClass.TRACK,
-    "object.item.audioItem.musicTrack": MediaClass.TRACK,
-    "object.item.audioItem.audioBroadcast": MediaClass.GENRE,
-    "object.item.audioItem.audioBook": MediaClass.TRACK,
+    UPNP_OBJECT_CONTAINER: MediaClass.DIRECTORY,
+    UPNP_OBJECT_ALBUM: MediaClass.ALBUM,
+    UPNP_OBJECT_GENRE: MediaClass.PLAYLIST,
+    UPNP_OBJECT_COMPOSER: MediaClass.PLAYLIST,
+    UPNP_OBJECT_ARTIST: MediaClass.ARTIST,
+    UPNP_OBJECT_PLAYLIST_SAME_ARTIST: MediaClass.ARTIST,
+    UPNP_OBJECT_PLAYLIST_CONTAINER: MediaClass.PLAYLIST,
+    UPNP_OBJECT_ITEM: MediaClass.TRACK,
+    UPNP_OBJECT_TRACK: MediaClass.TRACK,
+    UPNP_OBJECT_BROADCAST: MediaClass.GENRE,
+    UPNP_OBJECT_AUDIOBOOK: MediaClass.TRACK,
 }
 
 SONOS_TO_MEDIA_TYPES = {
@@ -84,17 +120,17 @@ SONOS_TO_MEDIA_TYPES = {
     SONOS_ARTIST: MediaType.CONTRIBUTING_ARTIST,
     SONOS_COMPOSER: MediaType.COMPOSER,
     SONOS_GENRE: MediaType.GENRE,
-    SONOS_PLAYLISTS: MediaType.PLAYLIST,
+    SONOS_PLAYLISTS: MediaClass.PLAYLIST,
     SONOS_TRACKS: MediaType.TRACK,
-    "object.container": MEDIA_TYPE_DIRECTORY,
-    "object.container.album.musicAlbum": MediaType.ALBUM,
-    "object.container.genre.musicGenre": MediaType.PLAYLIST,
-    "object.container.person.composer": MediaType.PLAYLIST,
-    "object.container.person.musicArtist": MediaType.ARTIST,
-    "object.container.playlistContainer.sameArtist": MediaType.ARTIST,
-    "object.container.playlistContainer": MediaType.PLAYLIST,
-    "object.item.audioItem.musicTrack": MediaType.TRACK,
-    "object.item.audioItem.audioBook": MediaType.TRACK,
+    UPNP_OBJECT_CONTAINER: MEDIA_TYPE_DIRECTORY,
+    UPNP_OBJECT_ALBUM: MediaType.ALBUM,
+    UPNP_OBJECT_GENRE: MediaClass.PLAYLIST,
+    UPNP_OBJECT_COMPOSER: MediaClass.PLAYLIST,
+    UPNP_OBJECT_ARTIST: MediaClass.ARTIST,
+    UPNP_OBJECT_PLAYLIST_SAME_ARTIST: MediaClass.ARTIST,
+    UPNP_OBJECT_PLAYLIST_CONTAINER: MediaClass.PLAYLIST,
+    UPNP_OBJECT_TRACK: MediaType.TRACK,
+    UPNP_OBJECT_AUDIOBOOK: MediaType.TRACK,
 }
 
 MEDIA_TYPES_TO_SONOS: dict[MediaType | str, str] = {
@@ -109,46 +145,37 @@ MEDIA_TYPES_TO_SONOS: dict[MediaType | str, str] = {
 }
 
 SONOS_TYPES_MAPPING = {
-    "A:ALBUM": SONOS_ALBUM,
-    "A:ALBUMARTIST": SONOS_ALBUM_ARTIST,
-    "A:ARTIST": SONOS_ARTIST,
-    "A:COMPOSER": SONOS_COMPOSER,
-    "A:GENRE": SONOS_GENRE,
-    "A:PLAYLISTS": SONOS_PLAYLISTS,
-    "A:TRACKS": SONOS_TRACKS,
-    "object.container.album.musicAlbum": SONOS_ALBUM,
-    "object.container.genre.musicGenre": SONOS_GENRE,
-    "object.container.person.composer": SONOS_COMPOSER,
-    "object.container.person.musicArtist": SONOS_ALBUM_ARTIST,
-    "object.container.playlistContainer.sameArtist": SONOS_ARTIST,
-    "object.container.playlistContainer": SONOS_PLAYLISTS,
-    "object.item": SONOS_OTHER_ITEM,
-    "object.item.audioItem.musicTrack": SONOS_TRACKS,
-    "object.item.audioItem.audioBroadcast": SONOS_RADIO,
-    "object.item.audioItem.audioBook": SONOS_AUDIO_BOOK,
+    LIB_KEY_ALBUM: SONOS_ALBUM,
+    LIB_KEY_ALBUM_ARTIST: SONOS_ALBUM_ARTIST,
+    LIB_KEY_ARTIST: SONOS_ARTIST,
+    LIB_KEY_COMPOSER: SONOS_COMPOSER,
+    LIB_KEY_GENRE: SONOS_GENRE,
+    LIB_KEY_PLAYLISTS: SONOS_PLAYLISTS,
+    LIB_KEY_TRACKS: SONOS_TRACKS,
+    UPNP_OBJECT_ALBUM: SONOS_ALBUM,
+    UPNP_OBJECT_GENRE: SONOS_GENRE,
+    UPNP_OBJECT_COMPOSER: SONOS_COMPOSER,
+    UPNP_OBJECT_ARTIST: SONOS_ALBUM_ARTIST,
+    UPNP_OBJECT_PLAYLIST_SAME_ARTIST: SONOS_ARTIST,
+    UPNP_OBJECT_PLAYLIST_CONTAINER: SONOS_PLAYLISTS,
+    UPNP_OBJECT_ITEM: SONOS_OTHER_ITEM,
+    UPNP_OBJECT_TRACK: SONOS_TRACKS,
+    UPNP_OBJECT_BROADCAST: SONOS_RADIO,
+    UPNP_OBJECT_AUDIOBOOK: SONOS_AUDIO_BOOK,
 }
 
 LIBRARY_TITLES_MAPPING = {
-    "A:ALBUM": "Albums",
-    "A:ALBUMARTIST": "Artists",
-    "A:ARTIST": "Contributing Artists",
-    "A:COMPOSER": "Composers",
-    "A:GENRE": "Genres",
-    "A:PLAYLISTS": "Playlists",
-    "A:TRACKS": "Tracks",
-    "S:": "Folders",
+    LIB_KEY_ALBUM: "Albums",
+    LIB_KEY_ALBUM_ARTIST: "Artists",
+    LIB_KEY_ARTIST: "Contributing Artists",
+    LIB_KEY_COMPOSER: "Composers",
+    LIB_KEY_GENRE: "Genres",
+    LIB_KEY_PLAYLISTS: "Playlists",
+    LIB_KEY_TRACKS: "Tracks",
+    LIB_KEY_FOLDERS: "Folders",
 }
 
-PLAYABLE_MEDIA_TYPES = [
-    MediaType.ALBUM,
-    MediaType.ARTIST,
-    MediaType.COMPOSER,
-    MediaType.CONTRIBUTING_ARTIST,
-    MediaType.GENRE,
-    MediaType.PLAYLIST,
-    MediaType.TRACK,
-]
-
+# Event and Service Strings
 SONOS_CHECK_ACTIVITY = "sonos_check_activity"
 SONOS_CREATE_ALARM = "sonos_create_alarm"
 SONOS_CREATE_AUDIO_FORMAT_SENSOR = "sonos_create_audio_format_sensor"
@@ -169,33 +196,26 @@ SONOS_STATE_UPDATED = "sonos_state_updated"
 SONOS_REBOOTED = "sonos_rebooted"
 SONOS_VANISHED = "sonos_vanished"
 
+# Source Types
 SOURCE_AIRPLAY = "AirPlay"
 SOURCE_LINEIN = "Line-in"
 SOURCE_SPOTIFY_CONNECT = "Spotify Connect"
 SOURCE_TV = "TV"
 
-MODELS_LINEIN_ONLY = (
-    "CONNECT",
-    "CONNECT:AMP",
-    "PORT",
-    "PLAY:5",
-)
-MODELS_TV_ONLY = (
-    "ARC",
-    "BEAM",
-    "PLAYBAR",
-    "PLAYBASE",
-    "ULTRA",
-)
+# Model Identifiers
+MODELS_LINEIN_ONLY = ("CONNECT", "CONNECT:AMP", "PORT", "PLAY:5")
+MODELS_TV_ONLY = ("ARC", "BEAM", "PLAYBAR", "PLAYBASE", "ULTRA")
 MODELS_LINEIN_AND_TV = ("AMP",)
 MODEL_SONOS_ARC_ULTRA = "SONOS ARC ULTRA"
 
+# Attribute Keys
 ATTR_SPEECH_ENHANCEMENT_ENABLED = "speech_enhance_enabled"
-SPEECH_DIALOG_LEVEL = "speech_dialog_level"
 ATTR_DIALOG_LEVEL = "dialog_level"
 ATTR_DIALOG_LEVEL_ENUM = "dialog_level_enum"
 ATTR_QUEUE_POSITION = "queue_position"
+SPEECH_DIALOG_LEVEL = "speech_dialog_level"
 
+# Timeouts and Intervals
 AVAILABILITY_CHECK_INTERVAL = datetime.timedelta(minutes=1)
 AVAILABILITY_TIMEOUT = AVAILABILITY_CHECK_INTERVAL.total_seconds() * 4.5
 BATTERY_SCAN_INTERVAL = datetime.timedelta(minutes=15)


### PR DESCRIPTION
USK yashwanth-group 4

## Proposed change
This issue was prioritized because the use of duplicated string literals, or "magic strings," adds significant risk and technical debt to the codebase. In this specific case, verbose strings for UPnP object paths and library keys were repeated across multiple dictionaries in sonos/const.py. This practice negatively impacts maintainability, as any change to a string requires finding and updating every instance, increasing the risk of typos and introducing bugs. It also harms readability, as a named constant is far more descriptive than a raw string.

By refactoring this file to define each string once as a descriptive constant and then referencing that constant, the logic becomes clearer, safer, and easier to maintain. This change aligns with Home Assistant’s emphasis on high-quality, maintainable code. Eliminating duplicated strings establishes a single source of truth, reduces cognitive load for developers, and improves overall code cleanliness, ensuring consistency with established coding best practices.

##Type of change
Code quality improvements to existing code or addition of tests

Additional information
This PR fixes or closes issue: SonarCloud Code Smell:"String literals should not be duplicated."
Related SonarCloud issue:
<img width="757" height="599" alt="Screenshot 2025-10-04 at 11 13 53 AM" src="https://github.com/user-attachments/assets/42cddae0-68cb-4888-98c3-da2d49d3d621" />





