### PR TITLE
remove unused variable default_interface in async_get_interfaces method

### DIFF
--- a/homeassistant/components/motion_blinds/gateway.py
+++ b/homeassistant/components/motion_blinds/gateway.py
@@ -78,7 +78,6 @@ class ConnectMotionGateway:
         """Get list of interface to use."""
         interfaces = [DEFAULT_INTERFACE, "0.0.0.0"]
         enabled_interfaces = []
-        default_interface = DEFAULT_INTERFACE
 
         adapters = await network.async_get_adapters(self._hass)
         for adapter in adapters:
@@ -87,8 +86,6 @@ class ConnectMotionGateway:
                 interfaces.append(ip4)
                 if adapter["enabled"]:
                     enabled_interfaces.append(ip4)
-                    if adapter["default"]:
-                        default_interface = ip4
 
         if len(enabled_interfaces) == 1:
             default_interface = enabled_interfaces[0]


### PR DESCRIPTION
**Simon Ljung** - Group 6

## Motivation (why this matters)
This removes a dead assignment to the local variable `default_interface`. Keeping unused locals harms maintainability by:

- Increasing cognitive load for readers who try to understand how `default_interface` affects control flow when it actually does not.  
- Risking future bugs if someone later assumes the variable is authoritative and “updates” it without effect.  
- Adding noise that blocks static analysis and code search from clearly showing the real data flow in `async_get_interfaces`.
- The issue was raised 3 years ago and have not been resolved by now.

Criterias:
Product: 2p
Process: 4p
Code-smell: 4p

Total: 10/18p


