### PR TITLE
Fix return type hint to include None

### DIFF
--- a/homeassistant/components/entur_public_transport/sensor.py
+++ b/homeassistant/components/entur_public_transport/sensor.py
@@ -81,7 +81,7 @@ ATTR_NEXT_UP_REALTIME = "next_real_time"
 ATTR_TRANSPORT_MODE = "transport_mode"
 
 
-def due_in_minutes(timestamp: datetime) -> int:
+def due_in_minutes(timestamp: datetime) -> int | None:
     """Get the time in minutes from a timestamp."""
     if timestamp is None:
         return None


### PR DESCRIPTION
Zeth Danielsson
This issue was prioritized because the function due_in_minutes currently has a type hint suggesting it returns an int, but it could also return None, which is a type mismatch. Although this is a small change (LoC: 1, complexity: 1) and requires low effort to fix (1), the issue has persisted for over a year and the function has not been modified in the last 9 months. Leaving the type hint incorrect can lead to confusion for future developers and potential type-related bugs in static analysis or IDEs.

Resolution

The issue was addressed by updating the function’s type hint to include None as a possible return value. This accurately reflects the function’s behavior, improving code clarity and preventing type errors, without introducing any functional changes.