### PR TITLE
Fix: Add None type hint to function

### DIFF
--- a/script/hassfest/quality_scale_validation/test_before_setup.py
+++ b/script/hassfest/quality_scale_validation/test_before_setup.py
@@ -15,7 +15,7 @@ _VALID_EXCEPTIONS = {
 }
 
 
-def _get_exception_name(expression: ast.expr) -> str:
+def _get_exception_name(expression: ast.expr) -> str | None:
     """Get the name of the exception being raised."""
     if expression is None:
         # Bare raise


### PR DESCRIPTION
Zeth Danielsson
The function _get_exception_name is annotated to return a str, but in practice it can also return None. This mismatch between the type hint and the actual behavior is a code smell, as it reduces clarity and may cause type checking tools or IDEs to report errors. Although the change is very small (LoC: 1, complexity: 1, effort: 1), the issue has persisted for 9 months (persistence: 2) and the file has not been updated in the last 6 months, showing that the problem was overlooked. Correct type annotations are important for maintainability and for ensuring future contributors understand function contracts.


The issue was addressed by updating the type hint of _get_exception_name to include None as a valid return type. This makes the function’s signature consistent with its behavior, improves type safety, and prevents confusion or false errors in static analysis