### PR TITLE
COGNITIVE COMPLEXITY OF FUNCTIONS SHOULD NOT BE TOO HIGH by AAKASH DOLI

### DIFF
--- a/homeassistant/helpers/area_registry.py
+++ b/homeassistant/helpers/area_registry.py
@@ -118,48 +118,58 @@ class AreaRegistryStore(Store[AreasRegistryStoreData]):
         old_data: dict[str, list[dict[str, Any]]],
     ) -> AreasRegistryStoreData:
         """Migrate to the new version."""
-        if old_major_version < 2:
-            if old_minor_version < 2:
-                # Version 1.2 implements migration and freezes the available keys
-                for area in old_data["areas"]:
-                    # Populate keys which were introduced before version 1.2
-                    area.setdefault("picture", None)
-
-            if old_minor_version < 3:
-                # Version 1.3 adds aliases
-                for area in old_data["areas"]:
-                    area["aliases"] = []
-
-            if old_minor_version < 4:
-                # Version 1.4 adds icon
-                for area in old_data["areas"]:
-                    area["icon"] = None
-
-            if old_minor_version < 5:
-                # Version 1.5 adds floor_id
-                for area in old_data["areas"]:
-                    area["floor_id"] = None
-
-            if old_minor_version < 6:
-                # Version 1.6 adds labels
-                for area in old_data["areas"]:
-                    area["labels"] = []
-
-            if old_minor_version < 7:
-                # Version 1.7 adds created_at and modified_at
-                created_at = utc_from_timestamp(0).isoformat()
-                for area in old_data["areas"]:
-                    area["created_at"] = area["modified_at"] = created_at
-
-            if old_minor_version < 8:
-                # Version 1.8 adds humidity_entity_id and temperature_entity_id
-                for area in old_data["areas"]:
-                    area["humidity_entity_id"] = None
-                    area["temperature_entity_id"] = None
 
         if old_major_version > 1:
             raise NotImplementedError
+
+        migrations = [
+            (2, self._migrate_picture),
+            (3, self._migrate_aliases),
+            (4, self._migrate_icon),
+            (5, self._migrate_floor_id),
+            (6, self._migrate_labels),
+            (7, self._migrate_created_modified),
+            (8, self._migrate_humidity_temperature),
+        ]
+
+        for version, migration in migrations:
+            if old_minor_version < version:
+                for area in old_data["areas"]:
+                    migration(area)
+
         return old_data  # type: ignore[return-value]
+
+    # --- Individual migration helpers ---
+
+    @staticmethod
+    def _migrate_picture(area: dict[str, Any]) -> None:
+        area.setdefault("picture", None)
+
+    @staticmethod
+    def _migrate_aliases(area: dict[str, Any]) -> None:
+        area["aliases"] = []
+
+    @staticmethod
+    def _migrate_icon(area: dict[str, Any]) -> None:
+        area["icon"] = None
+
+    @staticmethod
+    def _migrate_floor_id(area: dict[str, Any]) -> None:
+        area["floor_id"] = None
+
+    @staticmethod
+    def _migrate_labels(area: dict[str, Any]) -> None:
+        area["labels"] = []
+
+    @staticmethod
+    def _migrate_created_modified(area: dict[str, Any]) -> None:
+        created_at = utc_from_timestamp(0).isoformat()
+        area["created_at"] = area["modified_at"] = created_at
+
+    @staticmethod
+    def _migrate_humidity_temperature(area: dict[str, Any]) -> None:
+        area["humidity_entity_id"] = None
+        area["temperature_entity_id"] = None
 
 
 class AreaRegistryItems(NormalizedNameBaseRegistryItems[AreaEntry]):


### PR DESCRIPTION
## Proposed change
This change was prioritized because the original _async_migrate_func method in the AreaRegistryStore class had high cognitive complexity (37), making the logic difficult to read, maintain, and extend. The function relied on multiple nested conditionals and repeated migration steps, which introduced unnecessary duplication and reduced clarity.

The refactor restructures the migration process into a data-driven sequence using a list of version-to-function mappings and introduces dedicated helper methods for each migration step. This approach significantly reduces complexity, improves readability, and enhances scalability for future schema updates.

By simplifying the control flow and consolidating repeated patterns, the code becomes easier to reason about, safer to modify, and more aligned with Home Assistant’s standards for maintainable and clean code. While this change does not alter functionality, it provides long-term benefits in maintainability, reduces cognitive load for developers, and ensures consistent behavior across migrations.

This targeted improvement contributes to the project’s ongoing efforts to maintain a high-quality, professional, and easily maintainable codebase, fully in line with Home Assistant’s best practices for code health and clarity.

Aligns with Home Assistant’s ongoing code quality and best practice standards

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- code smell : Cognitive complexity of function should not be too high 
https://sonarcloud.io/project/issues?directories=homeassistant%2Fhelpers&impactSeverities=HIGH&rules=python%3AS3776&issueStatuses=OPEN%2CCONFIRMED&types=CODE_SMELL&id=aakashdoli_home-assistant-core-ht25&open=AZm0Jcu20iHIk9lFK91K
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
