### PR TITLE
STRING LITERAL SHOULD NOT BE DUPLICATED by NASANI AMOGHVARSHA

### DIFF
--- a/homeassistant/components/unifiprotect/binary_sensor.py
+++ b/homeassistant/components/unifiprotect/binary_sensor.py
@@ -39,6 +39,8 @@ from .entity import (
 )
 
 _KEY_DOOR = "door"
+_NEW_ICON_LOCK = "mdi:lock"
+_NEW_ICON_ON = "mdi:led-on"
 
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
@@ -72,7 +74,7 @@ CAMERA_SENSORS: tuple[ProtectBinaryEntityDescription, ...] = (
     ProtectBinaryEntityDescription(
         key="ssh",
         translation_key="ssh_enabled",
-        icon="mdi:lock",
+        icon=_NEW_ICON_LOCK,
         entity_registry_enabled_default=False,
         entity_category=EntityCategory.DIAGNOSTIC,
         ufp_value="is_ssh_enabled",
@@ -81,7 +83,7 @@ CAMERA_SENSORS: tuple[ProtectBinaryEntityDescription, ...] = (
     ProtectBinaryEntityDescription(
         key="status_light",
         translation_key="status_light",
-        icon="mdi:led-on",
+        icon=_NEW_ICON_ON,
         entity_category=EntityCategory.DIAGNOSTIC,
         ufp_required_field="feature_flags.has_led_status",
         ufp_value="led_settings.is_enabled",
@@ -314,7 +316,7 @@ LIGHT_SENSORS: tuple[ProtectBinaryEntityDescription, ...] = (
     ProtectBinaryEntityDescription(
         key="ssh",
         translation_key="ssh_enabled",
-        icon="mdi:lock",
+        icon=_NEW_ICON_LOCK,
         entity_registry_enabled_default=False,
         entity_category=EntityCategory.DIAGNOSTIC,
         ufp_value="is_ssh_enabled",
@@ -323,7 +325,7 @@ LIGHT_SENSORS: tuple[ProtectBinaryEntityDescription, ...] = (
     ProtectBinaryEntityDescription(
         key="status_light",
         translation_key="status_light",
-        icon="mdi:led-on",
+        icon=_NEW_ICON_ON,
         entity_category=EntityCategory.DIAGNOSTIC,
         ufp_value="light_device_settings.is_indicator_enabled",
         ufp_perm=PermRequired.NO_WRITE,
@@ -369,7 +371,7 @@ SENSE_SENSORS: tuple[ProtectBinaryEntityDescription, ...] = (
     ProtectBinaryEntityDescription(
         key="status_light",
         translation_key="status_light",
-        icon="mdi:led-on",
+        icon=_NEW_ICON_ON,
         entity_category=EntityCategory.DIAGNOSTIC,
         ufp_value="led_settings.is_enabled",
         ufp_perm=PermRequired.NO_WRITE,
@@ -576,7 +578,7 @@ DOORLOCK_SENSORS: tuple[ProtectBinaryEntityDescription, ...] = (
     ProtectBinaryEntityDescription(
         key="status_light",
         translation_key="status_light",
-        icon="mdi:led-on",
+        icon=_NEW_ICON_ON,
         entity_category=EntityCategory.DIAGNOSTIC,
         ufp_value="led_settings.is_enabled",
         ufp_perm=PermRequired.NO_WRITE,
@@ -587,7 +589,7 @@ VIEWER_SENSORS: tuple[ProtectBinaryEntityDescription, ...] = (
     ProtectBinaryEntityDescription(
         key="ssh",
         translation_key="ssh_enabled",
-        icon="mdi:lock",
+        icon=_NEW_ICON_LOCK,
         entity_registry_enabled_default=False,
         entity_category=EntityCategory.DIAGNOSTIC,
         ufp_value="is_ssh_enabled",


### PR DESCRIPTION
NASANI AMOGHVARSHA
### Proposed change
This PR refactors code to improve maintainability and eliminate code duplication by introducing constants for repeated icon string literals. The changes specifically address the duplication of the "mdi:lock" and "mdi:led-on" string literals in the UniFi Protect binary sensor component.

**Key improvements:**
- Introduced _ICON_LOCK constant for the "mdi:lock" string literal
- Introduced _ICON_LED_ON constant for the "mdi:led-on" string literal
- Replaced all 3 occurrences of "mdi:lock" with the new constant
- Replaced all 4 occurrences of "mdi:led-on" with the new constant
- Reduced potential for typos and inconsistencies across multiple sensor definitions
- Improved code readability and maintainability
- Follows existing code patterns in the codebase

These changes make the codebase more robust and easier to update in the future. By using constants, we ensure consistent usage throughout the component and make it simpler to modify these values if needed.

The refactoring affects the following sensor definitions:
"mdi:lock" replacements:
- Camera sensors (SSH enabled sensor)
- Light sensors (SSH enabled sensor)
- Viewer sensors (SSH enabled sensor)
- "mdi:led-on" replacements:
- Camera sensors (status light sensor)
- Light sensors (status light sensor)
- Sense sensors (status light sensor)
- Doorlock sensors (status light sensor)

### Type of change
1. Dependency upgrade
2. Bugfix (non-breaking change which fixes an issue)
3. New integration (thank you!)
4. New feature (which adds functionality to an existing integration)
5. Deprecation (breaking change to happen in the future)
6. Breaking change (fix/feature causing existing functionality to break)
7. Code quality improvements to existing code or addition of tests

### Additional information
1. This PR fixes or closes issue: fixes #
2. This PR is related to issue:
3. Link to documentation pull request:

### Checklist
[ X] I understand the code I am submitting and can explain how it works.
[ X] The code change is tested and works locally.
[ X] Local tests pass. Your PR cannot be merged unless tests pass
[ X] There is no commented out code in this PR.
[X ] I have followed the [development checklist][dev-checklist]
[X ] I have followed the [perfect PR recommendations][perfect-pr]
[X ] The code has been formatted using Ruff (ruff format homeassistant tests)
[ ] Tests have been added to verify that the new code works.
[ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.
If user exposed functionality or configuration variables are added/changed:

 Documentation added/updated for [www.home-assistant.io](url)

For testing I create a duplicate repo and completed the analysis and made changes to that repo by doing so the issue is not showing
[https://sonarcloud.io/project/issues?directories=homeassistant%2Fcomponents%2Funifiprotect&impactSeverities=HIGH&rules=python%3AS1192&severities=CRITICAL&issueStatuses=OPEN%2CCONFIRMED&types=CODE_SMELL&id=Nasaniamoghvarsha_home-assistant2&open=AZm1jjPY0iHIk9lFS0tD](url)
If the code communicates with devices, web services, or third-party tools:

 The [manifest file][manifest-docs] has all fields filled out correctly.
Updated and included derived files by running: python3 -m script.hassfest.
 New or updated dependencies have been added to requirements_all.txt.
Updated by running python3 -m script.gen_requirements_all.
 For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.