### PR TITLE
Cognitive complexity should not be high by Ekshith Satnur

### DIFF
--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -273,9 +273,7 @@ PRELOAD_STORAGE = [
 ]
 
 
-async def async_setup_hass(
-    runtime_config: RuntimeConfig,
-) -> core.HomeAssistant | None:
+async def async_setup_hass(runtime_config: RuntimeConfig) -> core.HomeAssistant | None:
     """Set up Home Assistant."""
 
     async def create_hass() -> core.HomeAssistant:
@@ -291,33 +289,33 @@ async def async_setup_hass(
             runtime_config.log_no_color,
         )
 
-        if runtime_config.debug or hass.loop.get_debug():
-            hass.config.debug = True
-
+        hass.config.debug = runtime_config.debug or hass.loop.get_debug()
         hass.config.safe_mode = runtime_config.safe_mode
         hass.config.skip_pip = runtime_config.skip_pip
         hass.config.skip_pip_packages = runtime_config.skip_pip_packages
-
         return hass
 
-    hass = await create_hass()
+    async def log_skip_pip_warnings() -> None:
+        """Log pip-skip warnings if applicable."""
+        if runtime_config.skip_pip or runtime_config.skip_pip_packages:
+            _LOGGER.warning(
+                "Skipping pip installation of required modules. This may cause issues"
+            )
 
-    if runtime_config.skip_pip or runtime_config.skip_pip_packages:
-        _LOGGER.warning(
-            "Skipping pip installation of required modules. This may cause issues"
-        )
+    async def ensure_config(hass: core.HomeAssistant) -> bool:
+        await log_skip_pip_warnings()
+        if not await conf_util.async_ensure_config_exists(hass):
+            _LOGGER.error("Error getting configuration path")
+            return False
 
-    if not await conf_util.async_ensure_config_exists(hass):
-        _LOGGER.error("Error getting configuration path")
-        return None
+        _LOGGER.info("Config directory: %s", runtime_config.config_dir)
+        block_async_io.enable()
+        return True
 
-    _LOGGER.info("Config directory: %s", runtime_config.config_dir)
-
-    block_async_io.enable()
-
-    if not (recovery_mode := runtime_config.recovery_mode):
-        config_dict = None
-        basic_setup_success = False
+    async def load_config(hass: core.HomeAssistant) -> tuple[dict | None, bool]:
+        """Load configuration and return config dict and success flag."""
+        if runtime_config.recovery_mode:
+            return None, False
 
         await hass.async_add_executor_job(conf_util.process_ha_config_upgrade, hass)
 
@@ -325,74 +323,71 @@ async def async_setup_hass(
             config_dict = await conf_util.async_hass_config_yaml(hass)
         except HomeAssistantError as err:
             _LOGGER.error(
-                "Failed to parse configuration.yaml: %s. Activating recovery mode",
-                err,
+                "Failed to parse configuration.yaml: %s. Activating recovery mode", err
             )
-        else:
-            if not is_virtual_env():
-                await async_mount_local_lib_path(runtime_config.config_dir)
+            return None, False
 
-            if hass.config.safe_mode:
-                _LOGGER.info("Starting in safe mode")
+        if not is_virtual_env():
+            await async_mount_local_lib_path(runtime_config.config_dir)
 
-            basic_setup_success = (
-                await async_from_config_dict(config_dict, hass) is not None
-            )
+        if hass.config.safe_mode:
+            _LOGGER.info("Starting in safe mode")
 
-        if config_dict is None:
-            recovery_mode = True
-            await hass.async_stop(force=True)
-            hass = await create_hass()
+        success = await async_from_config_dict(config_dict, hass) is not None
+        return config_dict, success
 
-        elif not basic_setup_success:
-            _LOGGER.warning(
-                "Unable to set up core integrations. Activating recovery mode"
-            )
-            recovery_mode = True
-            await hass.async_stop(force=True)
-            hass = await create_hass()
-
-        elif any(
-            domain not in hass.config.components for domain in CRITICAL_INTEGRATIONS
-        ):
-            _LOGGER.warning(
-                "Detected that %s did not load. Activating recovery mode",
-                ",".join(CRITICAL_INTEGRATIONS),
-            )
-
-            old_config = hass.config
-            old_logging = hass.data.get(DATA_LOGGING)
-
-            recovery_mode = True
-            await hass.async_stop(force=True)
-            hass = await create_hass()
-
-            if old_logging:
-                hass.data[DATA_LOGGING] = old_logging
-            hass.config.debug = old_config.debug
-            hass.config.skip_pip = old_config.skip_pip
-            hass.config.skip_pip_packages = old_config.skip_pip_packages
-            hass.config.internal_url = old_config.internal_url
-            hass.config.external_url = old_config.external_url
-            # Setup loader cache after the config dir has been set
-            loader.async_setup(hass)
-
-    if recovery_mode:
+    async def handle_recovery(
+        hass: core.HomeAssistant, old_state: dict | None = None
+    ) -> core.HomeAssistant:
+        """Start Home Assistant in recovery mode."""
         _LOGGER.info("Starting in recovery mode")
         hass.config.recovery_mode = True
-
         http_conf = (await http.async_get_last_config(hass)) or {}
+        await async_from_config_dict({"recovery_mode": {}, "http": http_conf}, hass)
 
-        await async_from_config_dict(
-            {"recovery_mode": {}, "http": http_conf},
-            hass,
-        )
+        if old_state:
+            for key in [
+                "debug",
+                "skip_pip",
+                "skip_pip_packages",
+                "internal_url",
+                "external_url",
+            ]:
+                if key in old_state:
+                    setattr(hass.config, key, old_state[key])
+            loader.async_setup(hass)
+
+        return hass
+
+    async def critical_integrations_ok(hass: core.HomeAssistant) -> bool:
+        """Check if all critical integrations loaded successfully."""
+        missing = [d for d in CRITICAL_INTEGRATIONS if d not in hass.config.components]
+        if not missing:
+            return True
+        _LOGGER.warning("Missing critical integrations: %s", ",".join(missing))
+        return False
+
+    # --- Main execution flow ---
+    hass = await create_hass()
+    if not await ensure_config(hass):
+        return None
+
+    config_dict, ok = await load_config(hass)
+    if config_dict is None or not ok or not await critical_integrations_ok(hass):
+        old_state = {
+            "debug": hass.config.debug,
+            "skip_pip": hass.config.skip_pip,
+            "skip_pip_packages": hass.config.skip_pip_packages,
+            "internal_url": hass.config.internal_url,
+            "external_url": hass.config.external_url,
+        }
+        await hass.async_stop(force=True)
+        hass = await handle_recovery(await create_hass(), old_state)
 
     if runtime_config.open_ui:
         hass.add_job(open_hass_ui, hass)
 
     return hass
-
 
 def open_hass_ui(hass: core.HomeAssistant) -> None:
     """Open the UI."""


### PR DESCRIPTION
**Proposed change**
This change was prioritised because the function async_setup_hass() had high cognitive complexity (more than 15) making the function's logic flow difficult to maintain. The function previously had complicated nested flows conditional statements which introduced unnecessary branching of execution flow. The refactor restructures the setup function  into smaller, dedicated helper functions such as create_hass, log_skip_pip_warnings, ensure_config, load_config, handle_recovery, and critical_integrations_ok. By dividing responsibilities to these helper functions, the overall control flow in async_setup_hass is simplified, more readable, and aligned with single-responsibility principles. This modular approach significantly reduces cognitive complexity (from 26 to the allowed threshold of 15), improves readability, and makes future modifications safer and easier. While the functionality remains unchanged, this improvement directly contributes to long-term code quality, reduces developer cognitive load. 
## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
https://sonarcloud.io/project/issues?impactSeverities=HIGH&rules=python%3AS3776&severities=CRITICAL&issueStatuses=OPEN%2CCONFIRMED&types=CODE_SMELL&id=EkshithSatnur_home-assistant-core-ht25&open=AZm0N_LVwjn1cF6zJjRU
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
