### PR TITLE
Refactor: update process_before_send typing

### DIFF
--- a/homeassistant/components/sentry/__init__.py
+++ b/homeassistant/components/sentry/__init__.py
@@ -120,14 +120,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 def process_before_send(
     hass: HomeAssistant,
-    options: Mapping[str, Any],
+    options: dict[str, Any],
     channel: str,
     huuid: str,
     system_info: dict[str, bool | str],
     custom_components: dict[str, Integration],
     event: dict[str, Any],
     hint: dict[str, Any],
-):
+) -> dict[str, Any] | None:
+    
     """Process a Sentry event before sending it to Sentry."""
     # Filter out handled events by default
     if (


### PR DESCRIPTION
P.SIVA SATHWIKA


## Proposed change

 This PR updates the type annotations in the process_before_send function within the Sentry integration.
The previous implementation used Mapping[str, Any], but the internal logic expects a mutable dictionary.
The updated signature now explicitly uses dict[str, Any], improving clarity, editor support, and type accuracy.

Additionally, the additional_tags construction was reorganized for readability.



## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ x] Code quality improvements to existing code or addition of tests

## Additional information

  This PR fixes or closes issue: N/A

This PR is related to issue: N/A

Link to documentation pull request: N/A

Link to developer documentation pull request: N/A

Link to frontend pull request: N/A



