### PR TITLE
modified test_entityfilter.py

### DIFF
--- a/tests/helpers/test_entityfilter.py
+++ b/tests/helpers/test_entityfilter.py
@@ -10,10 +10,10 @@ from homeassistant.helpers.entityfilter import (
 
 def test_no_filters_case_1() -> None:
     """If include and exclude not included, pass everything."""
-    incl_dom = {}
-    incl_ent = {}
-    excl_dom = {}
-    excl_ent = {}
+    incl_dom = []
+    incl_ent = []
+    excl_dom = []
+    excl_ent = []
     testfilter = generate_filter(incl_dom, incl_ent, excl_dom, excl_ent)
 
     for value in ("sensor.test", "sun.sun", "light.test"):


### PR DESCRIPTION

## Proposed change
The test test_entityfilter.py was passing empty dicts ({}) to generate_filter, but the function expects lists.
This caused type mismatches in tests and could lead to unreliable test results.

This PR refactors the test to pass empty lists ([]) instead of dicts, ensuring proper argument types and correct test execution.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x ] Code quality improvements to existing code or addition of tests

## Additional information

This PR fixes issue: S5655
Files changed:
tests/helpers/test_entityfilter.py
Motivation: Fix code smell by using correct argument types in tests.
Effort: ~120 minutes

